### PR TITLE
feat(core): add custom 404 error page

### DIFF
--- a/frontend/src/app/not-found.tsx
+++ b/frontend/src/app/not-found.tsx
@@ -1,0 +1,23 @@
+import Link from 'next/link';
+
+export default function NotFound() {
+  return (
+    <main className="flex min-h-[70vh] flex-col items-center justify-center p-4">
+      <div className="flex max-w-md flex-col items-center text-center">
+        <h1 className="text-6xl font-bold text-gray-900">404</h1>
+        <h2 className="mt-4 text-2xl font-semibold text-gray-800">
+          Página no encontrada
+        </h2>
+        <p className="mt-2 text-base text-gray-600">
+          Esta página ya fue reciclada o la dirección es incorrecta.
+        </p>
+        <Link
+          href="/"
+          className="mt-8 inline-flex justify-center rounded-lg bg-blue-600 px-6 py-3 text-sm font-medium text-white transition-colors hover:bg-blue-700"
+        >
+          Ir al inicio
+        </Link>
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
## What was changed?
Added a custom `not-found.tsx` Server Component in the Next.js App Router (`frontend/src/app/not-found.tsx`).

## Why was it changed?
To improve the User Experience (UX) by providing a friendly, branded error message when a user navigates to a broken link or non-existent route, allowing them to easily return to the home dashboard instead of seeing the default browser error.

## Related Tasks
- Resolves #46

## Checklist
- [x] Code builds successfully
- [x] Code follows agreed standards (No emojis, Tailwind logical order, Server Component by default)
- [x] No unrelated changes are included