### PR TITLE
HU-CORE-04-home-dashboard

### DIFF
--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -13,6 +13,9 @@ urlpatterns = [
     # TODO: uncomment when core auth endpoints are implemented
     # path("api/auth/", include("core.urls")),
 
+    # API: Core | api/core/dashboard
+    path("api/core/", include("core.urls")),
+
     # API: Marketplace | api/marketplace/products  api/marketplace/categories
     path("api/marketplace/", include("marketplace.urls")),
 

--- a/backend/core/serializers/__init__.py
+++ b/backend/core/serializers/__init__.py
@@ -1,0 +1,1 @@
+from .dashboard import DashboardSerializer

--- a/backend/core/serializers/dashboard.py
+++ b/backend/core/serializers/dashboard.py
@@ -1,0 +1,18 @@
+from rest_framework import serializers
+
+from marketplace.serializers.product import ProductListSerializer
+
+
+class GamificationSummarySerializer(serializers.Serializer):
+    """Placeholder for gamification data until module is implemented."""
+    points = serializers.IntegerField()
+    badges_count = serializers.IntegerField()
+
+
+class DashboardSerializer(serializers.Serializer):
+    """Aggregated dashboard response for the home page."""
+    recent_products = ProductListSerializer(many=True, read_only=True)
+    user_products = ProductListSerializer(many=True, read_only=True)
+    user_products_count = serializers.IntegerField()
+    active_transactions_count = serializers.IntegerField()
+    gamification = GamificationSummarySerializer()

--- a/backend/core/urls.py
+++ b/backend/core/urls.py
@@ -1,7 +1,7 @@
-# Scaffolding: URL routes for the core module (auth, user profile).
-# Add your auth endpoints here (register, login, token refresh, user profile).
-# See docs/architecture/modules.md for the expected endpoint list.
-# When ready, uncomment the path in config/urls.py to wire this in.
 from django.urls import path
 
-urlpatterns = []
+from core.views.dashboard import DashboardView
+
+urlpatterns = [
+    path("dashboard/", DashboardView.as_view(), name="dashboard"),
+]

--- a/backend/core/views/__init__.py
+++ b/backend/core/views/__init__.py
@@ -1,0 +1,1 @@
+from .dashboard import DashboardView

--- a/backend/core/views/dashboard.py
+++ b/backend/core/views/dashboard.py
@@ -1,0 +1,68 @@
+from rest_framework import status
+from rest_framework.response import Response
+from rest_framework.views import APIView
+from drf_spectacular.utils import extend_schema
+
+from marketplace.models import Products
+from marketplace.serializers.product import ProductListSerializer
+from core.serializers.dashboard import DashboardSerializer
+
+
+class DashboardView(APIView):
+    """Aggregated dashboard endpoint for the home page.
+
+    Returns recent products, user listings, and placeholder data
+    for transactions and gamification until those modules are ready.
+    """
+
+    @extend_schema(
+        summary="Get home dashboard data",
+        description=(
+            "Returns an aggregated view for the home dashboard including "
+            "recent products, user listings, active transactions count, "
+            "and gamification summary. Requires X-Mock-User-Id header."
+        ),
+        responses={200: DashboardSerializer},
+        tags=["Core > Dashboard"],
+    )
+    def get(self, request):
+        mock_user = getattr(request, "mock_user", None)
+
+        recent_products = (
+            Products.objects
+            .select_related("category", "seller")
+            .filter(status="disponible")
+            .order_by("-created_at")[:6]
+        )
+
+        user_products = []
+        user_products_count = 0
+        user_points = 0
+
+        if mock_user:
+            user_qs = (
+                Products.objects
+                .select_related("category", "seller")
+                .filter(seller=mock_user)
+                .order_by("-created_at")
+            )
+            user_products_count = user_qs.count()
+            user_products = user_qs[:3]
+            user_points = getattr(mock_user, "points", 0)
+
+        data = {
+            "recent_products": ProductListSerializer(
+                recent_products, many=True
+            ).data,
+            "user_products": ProductListSerializer(
+                user_products, many=True
+            ).data,
+            "user_products_count": user_products_count,
+            "active_transactions_count": 0,
+            "gamification": {
+                "points": user_points,
+                "badges_count": 0,
+            },
+        }
+
+        return Response(data, status=status.HTTP_200_OK)

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "clsx": "^2.1.0",
+        "lucide-react": "^0.576.0",
         "next": "^14.2.35",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -306,7 +307,6 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -364,7 +364,6 @@
       "integrity": "sha512-Ajr4IcMXq/2QmMkEmSvxqfLN5zGmJ92gHXAeOXq1OekoH2rfDNsgdDoL2f7QaRCy7G/E6TpxBVdRuNraMztGHw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "co": "^4.6.0",
         "fast-deep-equal": "^1.0.0",
@@ -639,7 +638,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -1631,7 +1629,6 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -1732,6 +1729,15 @@
       "dependencies": {
         "pseudomap": "^1.0.2",
         "yallist": "^2.1.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.576.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.576.0.tgz",
+      "integrity": "sha512-koNxU14BXrxUfZQ9cUaP0ES1uyPZKYDjk31FQZB6dQ/x+tXk979sVAn9ppZ/pVeJJyOxVM8j1E+8QEuSc02Vug==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/merge2": {
@@ -2114,7 +2120,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -2333,7 +2338,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -2346,7 +2350,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -2903,7 +2906,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "clsx": "^2.1.0",
+    "lucide-react": "^0.576.0",
     "next": "^14.2.35",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,30 +1,40 @@
 import type { Metadata } from 'next';
+import { Inter } from 'next/font/google';
 import Link from 'next/link';
 import './globals.css';
 
 import { MockAuthProvider } from '@/context/MockAuthContext';
 import MockUserSelector from '@/components/auth/MockUserSelector';
 
+const inter = Inter({
+  subsets: ['latin'],
+  variable: '--font-inter',
+  display: 'swap',
+});
+
 export const metadata: Metadata = {
   title: 'ReUseITESO',
-  description: 'Plataforma de compraventa de artículos de segunda mano para estudiantes del ITESO',
+  description: 'Plataforma de reuso de articulos para la comunidad ITESO',
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="es">
-      <body className="bg-gray-50 text-gray-900">
+    <html lang="es" className={inter.variable}>
+      <body className="bg-slate-50 font-sans text-slate-900 antialiased">
         <MockAuthProvider>
-          <header className="border-b border-gray-200 bg-white">
+          <header className="border-b border-iteso-800/20 bg-iteso-900">
             <div className="mx-auto flex max-w-6xl items-center justify-between px-6 py-3">
               <div className="flex items-center gap-6">
-                <Link href="/" className="text-lg font-bold text-blue-600">
+                <Link href="/" className="flex items-center gap-2 text-lg font-bold text-white">
+                  <span className="flex h-8 w-8 items-center justify-center rounded-lg bg-white/10 text-sm">
+                    ♻️
+                  </span>
                   ReUseITESO
                 </Link>
                 <nav className="flex items-center gap-4">
                   <Link
                     href="/products"
-                    className="text-sm font-medium text-gray-600 transition-colors hover:text-gray-900"
+                    className="text-sm font-medium text-white/70 transition-colors hover:text-white"
                   >
                     Productos
                   </Link>
@@ -33,7 +43,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
               <MockUserSelector />
             </div>
           </header>
-          <div className="mx-auto max-w-6xl">{children}</div>
+          <div className="mx-auto max-w-6xl px-6">{children}</div>
         </MockAuthProvider>
       </body>
     </html>

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,20 +1,9 @@
-import Link from 'next/link';
+import Dashboard from '@/components/dashboard/Dashboard';
 
 export default function HomePage() {
   return (
-    <main className="flex min-h-screen flex-col items-center justify-center gap-4 p-8">
-      <h1 className="text-4xl font-bold">ReUseITESO</h1>
-      <p className="text-lg text-gray-600">
-        Plataforma de compraventa de segunda mano para estudiantes del ITESO
-      </p>
-
-      {/* TODO: reemplazar con navegacion real cuando exista layout con header */}
-      <Link
-        href="/products"
-        className="rounded-lg bg-blue-600 px-4 py-2 font-medium text-white transition-colors hover:bg-blue-700"
-      >
-        Ver productos
-      </Link>
+    <main>
+      <Dashboard />
     </main>
   );
 }

--- a/frontend/src/components/auth/MockUserSelector.tsx
+++ b/frontend/src/components/auth/MockUserSelector.tsx
@@ -17,8 +17,8 @@ export default function MockUserSelector() {
   return (
     <div className="flex items-center gap-2.5">
       {isAuthenticated && (
-        <span className="inline-flex items-center gap-1.5 rounded-full bg-green-50 px-2.5 py-1 text-xs font-medium text-green-700 ring-1 ring-inset ring-green-200">
-          <span className="h-1.5 w-1.5 rounded-full bg-green-500" />
+        <span className="inline-flex items-center gap-1.5 rounded-full bg-emerald-500/20 px-2.5 py-1 text-xs font-medium text-emerald-300 ring-1 ring-inset ring-emerald-400/30">
+          <span className="h-1.5 w-1.5 rounded-full bg-emerald-400" />
           {currentUser?.name}
         </span>
       )}
@@ -27,11 +27,13 @@ export default function MockUserSelector() {
         aria-label="Seleccionar usuario"
         value={currentUser?.id ?? ''}
         onChange={handleChange}
-        className="rounded-lg border border-gray-300 bg-gray-50 px-3 py-1.5 text-sm text-gray-700 transition-colors focus:border-blue-500 focus:bg-white focus:outline-none focus:ring-2 focus:ring-blue-500/20"
+        className="rounded-lg border border-white/20 bg-white/10 px-3 py-1.5 text-sm text-white transition-colors focus:border-white/40 focus:bg-white/15 focus:outline-none focus:ring-2 focus:ring-white/20"
       >
-        <option value="">Sin usuario</option>
-        {availableUsers.map((user) => (
-          <option key={user.id} value={user.id}>
+        <option value="" className="bg-iteso-900 text-white">
+          Sin usuario
+        </option>
+        {availableUsers.map(user => (
+          <option key={user.id} value={user.id} className="bg-iteso-900 text-white">
             {user.name}
           </option>
         ))}

--- a/frontend/src/components/dashboard/Dashboard.tsx
+++ b/frontend/src/components/dashboard/Dashboard.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import { useMockAuth } from '@/context/MockAuthContext';
+import { useDashboard } from '@/hooks/useDashboard';
+
+import WelcomeHeader from '@/components/dashboard/WelcomeHeader';
+import QuickActions from '@/components/dashboard/QuickActions';
+import StatsSummary from '@/components/dashboard/StatsSummary';
+import MyListings from '@/components/dashboard/MyListings';
+import RecentProducts from '@/components/dashboard/RecentProducts';
+
+export default function Dashboard() {
+  const { isAuthenticated } = useMockAuth();
+  const { data, isLoading, error, refetch } = useDashboard();
+
+  return (
+    <div className="space-y-8 py-8">
+      <WelcomeHeader />
+      <QuickActions />
+
+      {isAuthenticated && <StatsSummary data={data} isLoading={isLoading} />}
+
+      <MyListings
+        products={data?.user_products ?? []}
+        totalCount={data?.user_products_count ?? 0}
+        isLoading={isLoading}
+        isAuthenticated={isAuthenticated}
+      />
+
+      <RecentProducts
+        products={data?.recent_products ?? []}
+        isLoading={isLoading}
+        error={error}
+        onRetry={refetch}
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/dashboard/MyListings.tsx
+++ b/frontend/src/components/dashboard/MyListings.tsx
@@ -1,0 +1,70 @@
+import Link from 'next/link';
+import { ArrowRight } from 'lucide-react';
+
+import ProductCard from '@/components/products/ProductCard';
+import Skeleton from '@/components/ui/Skeleton';
+import EmptyState from '@/components/ui/EmptyState';
+
+import type { Product } from '@/types/product';
+
+interface MyListingsProps {
+  products: Product[];
+  totalCount: number;
+  isLoading: boolean;
+  isAuthenticated: boolean;
+}
+
+export default function MyListings({
+  products,
+  totalCount,
+  isLoading,
+  isAuthenticated,
+}: MyListingsProps) {
+  if (!isAuthenticated) return null;
+
+  return (
+    <section>
+      <div className="mb-4 flex items-center justify-between">
+        <h2 className="text-lg font-semibold text-slate-900">Mis publicaciones</h2>
+        {totalCount > 3 && (
+          <Link
+            href="/products?mine=true"
+            className="flex items-center gap-1 text-sm font-medium text-iteso-600 transition-colors hover:text-iteso-700"
+          >
+            Ver todas ({totalCount})
+            <ArrowRight className="h-4 w-4" />
+          </Link>
+        )}
+      </div>
+
+      {isLoading && (
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {[1, 2, 3].map(i => (
+            <div key={i} className="rounded-2xl border border-slate-200 bg-white p-4">
+              <Skeleton className="mb-3 h-44 w-full rounded-xl" />
+              <Skeleton className="mb-2 h-4 w-20" />
+              <Skeleton className="mb-2 h-5 w-full" />
+              <Skeleton className="h-5 w-16" />
+            </div>
+          ))}
+        </div>
+      )}
+
+      {!isLoading && products.length === 0 && (
+        <EmptyState
+          message="Aun no has publicado nada"
+          actionLabel="Publicar mi primer item"
+          onAction={() => (window.location.href = '/products/new')}
+        />
+      )}
+
+      {!isLoading && products.length > 0 && (
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {products.map(product => (
+            <ProductCard key={product.id} product={product} />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/components/dashboard/QuickActions.tsx
+++ b/frontend/src/components/dashboard/QuickActions.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import Link from 'next/link';
+import { Plus, Search, Package } from 'lucide-react';
+
+import { useMockAuth } from '@/context/MockAuthContext';
+
+const ACTIONS = [
+  {
+    href: '/products/new',
+    icon: Plus,
+    label: 'Publicar item',
+    description: 'Comparte algo con la comunidad',
+    color: 'text-iteso-600',
+    hoverBg: 'hover:bg-iteso-50',
+    iconBg: 'bg-iteso-100',
+  },
+  {
+    href: '/products',
+    icon: Search,
+    label: 'Explorar marketplace',
+    description: 'Encuentra lo que necesitas',
+    color: 'text-emerald-600',
+    hoverBg: 'hover:bg-emerald-50',
+    iconBg: 'bg-emerald-100',
+  },
+  {
+    href: '/products?mine=true',
+    icon: Package,
+    label: 'Mis publicaciones',
+    description: 'Administra tus items',
+    color: 'text-amber-600',
+    hoverBg: 'hover:bg-amber-50',
+    iconBg: 'bg-amber-100',
+  },
+] as const;
+
+export default function QuickActions() {
+  const { isAuthenticated } = useMockAuth();
+
+  if (!isAuthenticated) return null;
+
+  return (
+    <div className="grid gap-4 sm:grid-cols-3">
+      {ACTIONS.map(action => {
+        const Icon = action.icon;
+        return (
+          <Link
+            key={action.href}
+            href={action.href}
+            className={`group flex items-center gap-4 rounded-2xl border border-slate-200 bg-white p-4 shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:shadow-md ${action.hoverBg}`}
+          >
+            <div
+              className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-xl ${action.iconBg} transition-transform duration-200 group-hover:scale-110`}
+            >
+              <Icon className={`h-5 w-5 ${action.color}`} />
+            </div>
+            <div>
+              <p className="text-sm font-semibold text-slate-900">{action.label}</p>
+              <p className="text-xs text-slate-500">{action.description}</p>
+            </div>
+          </Link>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/src/components/dashboard/RecentProducts.tsx
+++ b/frontend/src/components/dashboard/RecentProducts.tsx
@@ -1,0 +1,66 @@
+import Link from 'next/link';
+import { ArrowRight } from 'lucide-react';
+
+import ProductCard from '@/components/products/ProductCard';
+import Skeleton from '@/components/ui/Skeleton';
+import ErrorMessage from '@/components/ui/ErrorMessage';
+
+import type { Product } from '@/types/product';
+
+interface RecentProductsProps {
+  products: Product[];
+  isLoading: boolean;
+  error: string | null;
+  onRetry: () => void;
+}
+
+export default function RecentProducts({
+  products,
+  isLoading,
+  error,
+  onRetry,
+}: RecentProductsProps) {
+  return (
+    <section>
+      <div className="mb-4 flex items-center justify-between">
+        <h2 className="text-lg font-semibold text-slate-900">Lo mas reciente</h2>
+        <Link
+          href="/products"
+          className="flex items-center gap-1 text-sm font-medium text-iteso-600 transition-colors hover:text-iteso-700"
+        >
+          Ver todos
+          <ArrowRight className="h-4 w-4" />
+        </Link>
+      </div>
+
+      {isLoading && (
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {[1, 2, 3, 4, 5, 6].map(i => (
+            <div key={i} className="rounded-2xl border border-slate-200 bg-white p-4">
+              <Skeleton className="mb-3 h-44 w-full rounded-xl" />
+              <Skeleton className="mb-2 h-4 w-20" />
+              <Skeleton className="mb-2 h-5 w-full" />
+              <Skeleton className="h-5 w-16" />
+            </div>
+          ))}
+        </div>
+      )}
+
+      {error && <ErrorMessage message={error} onRetry={onRetry} />}
+
+      {!isLoading && !error && products.length > 0 && (
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {products.map(product => (
+            <ProductCard key={product.id} product={product} />
+          ))}
+        </div>
+      )}
+
+      {!isLoading && !error && products.length === 0 && (
+        <p className="py-8 text-center text-sm text-slate-500">
+          No hay productos publicados todavia
+        </p>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/components/dashboard/StatsSummary.tsx
+++ b/frontend/src/components/dashboard/StatsSummary.tsx
@@ -1,0 +1,77 @@
+import { Package, ArrowLeftRight, Award } from 'lucide-react';
+
+import Skeleton from '@/components/ui/Skeleton';
+
+import type { DashboardData } from '@/types/dashboard';
+
+interface StatsSummaryProps {
+  data: DashboardData | null;
+  isLoading: boolean;
+}
+
+const STATS_CONFIG = [
+  {
+    key: 'user_products_count' as const,
+    label: 'Mis publicaciones',
+    icon: Package,
+    borderColor: 'border-iteso-500',
+    textColor: 'text-iteso-600',
+    iconColor: 'text-iteso-400',
+  },
+  {
+    key: 'active_transactions_count' as const,
+    label: 'Transacciones activas',
+    icon: ArrowLeftRight,
+    borderColor: 'border-emerald-500',
+    textColor: 'text-emerald-600',
+    iconColor: 'text-emerald-400',
+  },
+];
+
+export default function StatsSummary({ data, isLoading }: StatsSummaryProps) {
+  if (isLoading) {
+    return (
+      <div className="grid gap-4 sm:grid-cols-3">
+        {[1, 2, 3].map(i => (
+          <div key={i} className="rounded-2xl border border-slate-200 bg-white p-5">
+            <Skeleton className="mb-2 h-8 w-16" />
+            <Skeleton className="h-4 w-24" />
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  if (!data) return null;
+
+  return (
+    <div className="grid gap-4 sm:grid-cols-3">
+      {STATS_CONFIG.map(stat => {
+        const Icon = stat.icon;
+        const value = data[stat.key];
+        return (
+          <div
+            key={stat.key}
+            className={`rounded-2xl border border-slate-200 border-l-4 ${stat.borderColor} bg-white p-5 shadow-sm`}
+          >
+            <div className="flex items-center justify-between">
+              <p className={`text-3xl font-bold tracking-tight ${stat.textColor}`}>{value}</p>
+              <Icon className={`h-5 w-5 ${stat.iconColor}`} />
+            </div>
+            <p className="mt-1 text-sm text-slate-500">{stat.label}</p>
+          </div>
+        );
+      })}
+
+      <div className="rounded-2xl border border-slate-200 border-l-4 border-amber-400 bg-white p-5 shadow-sm">
+        <div className="flex items-center justify-between">
+          <p className="text-3xl font-bold tracking-tight text-amber-600">
+            {data.gamification.points}
+          </p>
+          <Award className="h-5 w-5 text-amber-400" />
+        </div>
+        <p className="mt-1 text-sm text-slate-500">Puntos</p>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/dashboard/WelcomeHeader.tsx
+++ b/frontend/src/components/dashboard/WelcomeHeader.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import { Recycle } from 'lucide-react';
+
+import { useMockAuth } from '@/context/MockAuthContext';
+
+export default function WelcomeHeader() {
+  const { currentUser, isAuthenticated } = useMockAuth();
+
+  return (
+    <div className="relative overflow-hidden rounded-2xl bg-gradient-to-br from-iteso-900 to-iteso-700 p-6 text-white sm:p-8">
+      <div className="relative z-10">
+        <h1 className="text-2xl font-bold tracking-tight sm:text-3xl">
+          {isAuthenticated ? `Hola, ${currentUser?.name}` : 'Bienvenido a ReUseITESO'}
+        </h1>
+        <p className="mt-1 text-sm text-white/70 sm:text-base">
+          {isAuthenticated
+            ? 'Esto es lo nuevo en la comunidad ITESO'
+            : 'Selecciona un usuario para ver tu dashboard personalizado'}
+        </p>
+        <div className="mt-3 h-0.5 w-16 rounded-full bg-red-500" />
+      </div>
+      <Recycle
+        className="absolute -bottom-4 -right-4 h-32 w-32 text-white/5 sm:h-40 sm:w-40"
+        strokeWidth={1}
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/products/ProductCard.tsx
+++ b/frontend/src/components/products/ProductCard.tsx
@@ -8,14 +8,14 @@ interface ProductCardProps {
 }
 
 const CATEGORY_COLORS: Record<string, string> = {
-  Libros: 'bg-[#2B7FFF]/10 text-[#2B7FFF]',
-  'Electronica': 'bg-[#AD46FF]/10 text-[#AD46FF]',
-  'Ropa ITESO': 'bg-[#F6339A]/10 text-[#F6339A]',
-  Calculadoras: 'bg-[#FF6900]/10 text-[#FF6900]',
-  Apuntes: 'bg-[#10B981]/10 text-[#10B981]',
+  Libros: 'bg-iteso-500/10 text-iteso-600',
+  Electronica: 'bg-purple-500/10 text-purple-600',
+  'Ropa ITESO': 'bg-pink-500/10 text-pink-600',
+  Calculadoras: 'bg-amber-500/10 text-amber-600',
+  Apuntes: 'bg-emerald-500/10 text-emerald-600',
 };
 
-const DEFAULT_CATEGORY_CLASS = 'bg-gray-100 text-gray-700';
+const DEFAULT_CATEGORY_CLASS = 'bg-slate-100 text-slate-600';
 
 function getCategoryClass(categoryName: string): string {
   return CATEGORY_COLORS[categoryName] ?? DEFAULT_CATEGORY_CLASS;
@@ -30,8 +30,8 @@ export default function ProductCard({ product }: ProductCardProps) {
   const categoryClass = getCategoryClass(product.category.name);
 
   return (
-    <article className="flex flex-col overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm transition-shadow hover:shadow-md">
-      <div className="flex h-44 items-center justify-center bg-gray-100">
+    <article className="flex flex-col overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:shadow-md">
+      <div className="flex h-44 items-center justify-center bg-slate-100">
         {product.image_url ? (
           <img
             src={product.image_url}
@@ -39,8 +39,8 @@ export default function ProductCard({ product }: ProductCardProps) {
             className="h-full w-full object-cover"
           />
         ) : (
-          <span className="text-sm text-gray-400">
-            {product.category.name} - Imagen
+          <span className="text-sm text-slate-400">
+            {product.category.name}
           </span>
         )}
       </div>
@@ -48,18 +48,18 @@ export default function ProductCard({ product }: ProductCardProps) {
       <div className="flex flex-1 flex-col gap-2 p-4">
         <Badge className={categoryClass}>{product.category.name}</Badge>
 
-        <h3 className="line-clamp-2 text-base font-semibold text-gray-900">
+        <h3 className="line-clamp-2 text-base font-semibold text-slate-900">
           {product.title}
         </h3>
 
-        <p className="text-lg font-bold text-blue-600">{transactionDisplay}</p>
+        <p className="text-lg font-bold text-iteso-800">{transactionDisplay}</p>
 
-        <div className="mt-auto flex flex-col gap-1 text-xs text-gray-500">
+        <div className="mt-auto flex flex-col gap-1 text-xs text-slate-400">
           <span className="flex items-center gap-1">{timeAgo}</span>
         </div>
 
-        <div className="mt-2 flex items-center gap-2 border-t border-gray-100 pt-3">
-          <span className="text-sm text-gray-700">{product.seller_name}</span>
+        <div className="mt-2 flex items-center gap-2 border-t border-slate-100 pt-3">
+          <span className="text-sm text-slate-600">{product.seller_name}</span>
         </div>
       </div>
     </article>

--- a/frontend/src/components/products/ProductList.tsx
+++ b/frontend/src/components/products/ProductList.tsx
@@ -79,12 +79,12 @@ export default function ProductList() {
                             type="button"
                             disabled={!hasPrevPage}
                             onClick={() => goToPage(currentPage - 1)}
-                            className="rounded-lg border border-gray-300 px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+                            className="rounded-xl border border-slate-200 px-4 py-2 text-sm text-slate-700 hover:bg-slate-100 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
                         >
                             ← Anterior
                         </button>
 
-                        <span className="text-sm text-gray-500">
+                        <span className="text-sm text-slate-500">
                             Página {currentPage} &nbsp;·&nbsp; {totalCount} productos
                         </span>
 
@@ -92,7 +92,7 @@ export default function ProductList() {
                             type="button"
                             disabled={!hasNextPage}
                             onClick={() => goToPage(currentPage + 1)}
-                            className="rounded-lg border border-gray-300 px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+                            className="rounded-xl border border-slate-200 px-4 py-2 text-sm text-slate-700 hover:bg-slate-100 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
                         >
                             Siguiente →
                         </button>

--- a/frontend/src/components/ui/Button.tsx
+++ b/frontend/src/components/ui/Button.tsx
@@ -1,7 +1,8 @@
 interface ButtonProps {
   children: React.ReactNode;
   type?: 'button' | 'submit' | 'reset';
-  variant?: 'primary' | 'secondary' | 'danger';
+  variant?: 'primary' | 'secondary' | 'ghost' | 'danger';
+  size?: 'sm' | 'md' | 'lg';
   disabled?: boolean;
   onClick?: () => void;
 }
@@ -10,15 +11,24 @@ export default function Button({
   children,
   type = 'button',
   variant = 'primary',
+  size = 'md',
   disabled = false,
   onClick,
 }: ButtonProps) {
-  const baseStyles = 'px-4 py-2 rounded-lg font-medium transition-colors disabled:opacity-50';
+  const baseStyles =
+    'inline-flex items-center justify-center rounded-xl font-medium transition-all duration-150 disabled:opacity-50 disabled:cursor-not-allowed';
 
   const variantStyles = {
-    primary: 'bg-blue-600 text-white hover:bg-blue-700',
-    secondary: 'bg-gray-200 text-gray-800 hover:bg-gray-300',
-    danger: 'bg-red-600 text-white hover:bg-red-700',
+    primary: 'bg-iteso-800 text-white hover:bg-iteso-700 active:bg-iteso-900',
+    secondary: 'bg-slate-100 text-slate-700 hover:bg-slate-200 active:bg-slate-300',
+    ghost: 'text-iteso-600 hover:bg-iteso-50 active:bg-iteso-100',
+    danger: 'bg-red-600 text-white hover:bg-red-700 active:bg-red-800',
+  };
+
+  const sizeStyles = {
+    sm: 'px-3 py-1.5 text-sm gap-1.5',
+    md: 'px-4 py-2 text-sm gap-2',
+    lg: 'px-5 py-2.5 text-base gap-2',
   };
 
   return (
@@ -26,7 +36,7 @@ export default function Button({
       type={type}
       disabled={disabled}
       onClick={onClick}
-      className={`${baseStyles} ${variantStyles[variant]}`}
+      className={`${baseStyles} ${variantStyles[variant]} ${sizeStyles[size]}`}
     >
       {children}
     </button>

--- a/frontend/src/components/ui/Card.tsx
+++ b/frontend/src/components/ui/Card.tsx
@@ -1,17 +1,20 @@
-// Scaffolding: reusable Card component for consistent container styling.
-// The team can modify the default classes or add variants as needed.
-// See reglas_de_escritura_front.md section 6 for component organization.
-
 import type { ReactNode } from 'react';
 
 interface CardProps {
   children: ReactNode;
   className?: string;
+  hover?: boolean;
 }
 
-export default function Card({ children, className = '' }: CardProps) {
+export default function Card({ children, className = '', hover = false }: CardProps) {
+  const hoverStyles = hover
+    ? 'cursor-pointer transition-all duration-200 hover:shadow-md hover:-translate-y-0.5'
+    : '';
+
   return (
-    <div className={`rounded-xl border border-gray-200 bg-white p-4 shadow-sm ${className}`}>
+    <div
+      className={`rounded-2xl border border-slate-200 bg-white p-5 shadow-sm ${hoverStyles} ${className}`}
+    >
       {children}
     </div>
   );

--- a/frontend/src/components/ui/EmptyState.tsx
+++ b/frontend/src/components/ui/EmptyState.tsx
@@ -6,12 +6,12 @@ interface EmptyStateProps {
 
 export default function EmptyState({ message, actionLabel, onAction }: EmptyStateProps) {
   return (
-    <div className="flex flex-col items-center gap-4 p-8 text-center">
-      <p className="text-gray-500">{message}</p>
+    <div className="flex flex-col items-center gap-4 rounded-2xl border border-dashed border-slate-300 bg-slate-50 p-8 text-center">
+      <p className="text-sm text-slate-500">{message}</p>
       {actionLabel && onAction && (
         <button
           onClick={onAction}
-          className="rounded-lg bg-blue-600 px-4 py-2 text-sm text-white hover:bg-blue-700"
+          className="rounded-xl bg-iteso-800 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-iteso-700"
         >
           {actionLabel}
         </button>

--- a/frontend/src/components/ui/ErrorMessage.tsx
+++ b/frontend/src/components/ui/ErrorMessage.tsx
@@ -5,12 +5,12 @@ interface ErrorMessageProps {
 
 export default function ErrorMessage({ message, onRetry }: ErrorMessageProps) {
   return (
-    <div className="flex flex-col items-center gap-4 p-8 text-center">
-      <p className="text-red-600">{message}</p>
+    <div className="flex flex-col items-center gap-3 rounded-2xl border border-red-200 bg-red-50 p-6 text-center">
+      <p className="text-sm text-red-700">{message}</p>
       {onRetry && (
         <button
           onClick={onRetry}
-          className="rounded-lg bg-gray-200 px-4 py-2 text-sm hover:bg-gray-300"
+          className="rounded-xl bg-red-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-red-700"
         >
           Reintentar
         </button>

--- a/frontend/src/hooks/useDashboard.ts
+++ b/frontend/src/hooks/useDashboard.ts
@@ -1,0 +1,33 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+import { apiClient } from '@/lib/api';
+
+import type { DashboardData } from '@/types/dashboard';
+
+export function useDashboard() {
+  const [data, setData] = useState<DashboardData | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchDashboard = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const response = await apiClient<DashboardData>('/core/dashboard/');
+      setData(response);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Error al cargar el dashboard';
+      setError(message);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchDashboard();
+  }, [fetchDashboard]);
+
+  return { data, isLoading, error, refetch: fetchDashboard };
+}

--- a/frontend/src/types/dashboard.ts
+++ b/frontend/src/types/dashboard.ts
@@ -1,0 +1,14 @@
+import type { Product } from '@/types/product';
+
+export interface GamificationSummary {
+  points: number;
+  badges_count: number;
+}
+
+export interface DashboardData {
+  recent_products: Product[];
+  user_products: Product[];
+  user_products_count: number;
+  active_transactions_count: number;
+  gamification: GamificationSummary;
+}

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -2,7 +2,29 @@
 module.exports = {
   content: ['./src/**/*.{js,ts,jsx,tsx,mdx}'],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        iteso: {
+          50: '#EFF6FF',
+          100: '#DBEAFE',
+          200: '#BFDBFE',
+          300: '#93C5FD',
+          400: '#60A5FA',
+          500: '#3B7CB8',
+          600: '#2D6498',
+          700: '#244F7A',
+          800: '#1B3A5C',
+          900: '#0F2A4A',
+          950: '#0A1E35',
+        },
+      },
+      fontFamily: {
+        sans: ['var(--font-inter)', 'system-ui', 'sans-serif'],
+      },
+      borderRadius: {
+        '2xl': '1rem',
+      },
+    },
   },
   plugins: [],
 };


### PR DESCRIPTION
## 📌 Summary

Implements HU-CORE-04: home dashboard with recent activity. Adds a new aggregated backend endpoint (GET /api/core/dashboard/) and replaces the placeholder home page with a full dashboard. Also introduces the ITESO navy design system across existing UI components.

---

## 🔍 Type of Change

- [x] Feature (new functionality)
- [ ] Bug fix
- [ ] Agent (development tooling)
- [ ] Documentation
- [x] Refactor / cleanup
- [ ] CI / DevOps

---

## 🧩 Scope

- [x] Backend
- [x] Frontend
- [ ] Agents
- [ ] Docs
- [ ] CI / Infrastructure

---

## 🤖 Agent Details (if applicable)

N/A

---

## 🧪 Testing

- [x] Local execution
- [x] Manual testing
- [ ] Unit tests
- [ ] Not applicable (explain why)

Frontend builds successfully with next build (0 TypeScript errors). Dashboard renders correctly without backend (shows error state with retry). Dashboard renders correctly with backend connected (all 5 sections with data). Mock user selector switches users and updates dashboard content. Responsive layout verified on mobile and desktop.

---

## 📎 Related Context

- User Story: HU-CORE-04 - User can view the home dashboard with recent activity
- Uses existing ProductListSerializer and MockAuthMiddleware
- Transactions count and gamification points return 0 until those modules implement their endpoints
- core/urls.py was activated in config/urls.py (previously commented out)
- New dependency: lucide-react for icons

---

## ✅ Checklist

- [x] Code builds and runs locally
- [x] Changes are small and focused
- [x] Code follows agreed standards
- [x] Documentation was updated if needed
- [x] No unrelated changes are included
- [x] AI-generated content was reviewed and understood

---

## 📝 Notes for Reviewers

Design system changes affect existing components (Button, Card, EmptyState, ErrorMessage, ProductCard) — colors changed from blue-600/gray to iteso-*/slate-*. This is intentional to establish the ITESO visual identity and will also affect the /products page.

The dashboard works without auth. When no user is selected it shows a generic welcome and only "Lo mas reciente". Quick actions, stats, and "Mis publicaciones" appear only when a mock user is selected.

Transactions and gamification are placeholders. The endpoint returns active_transactions_count: 0 and gamification.points from the User model. When those teams finish their endpoints, only dashboard.py needs to be updated.
