### PR TITLE
Hu core 04 home dashboard 2

### DIFF
--- a/backend/core/urls.py
+++ b/backend/core/urls.py
@@ -15,4 +15,7 @@ urlpatterns = [
      # HU-CORE-09: Email verification module
     path("email-verification/send/", views.EmailVerificationSendView.as_view(), name="email_verification_send"),
     path("email-verification/confirm/", views.EmailVerificationConfirmView.as_view(), name="email_verification_confirm"),
+
+    # HU-CORE-04: Dashboard
+    path("dashboard/", views.DashboardView.as_view(), name="dashboard"),
 ]

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -339,3 +339,55 @@ class EmailVerificationConfirmView(APIView):
             },
             status=status.HTTP_200_OK,
         )
+
+
+# ── Dashboard ────────────────────────────────────────────
+
+from marketplace.models import Products
+from marketplace.serializers.product import ProductListSerializer
+
+
+class DashboardView(APIView):
+    """Aggregated dashboard endpoint for the home page."""
+
+    permission_classes = [AllowAny]
+
+    def get(self, request):
+        recent_products = (
+            Products.objects
+            .select_related("category", "seller")
+            .filter(status="disponible")
+            .order_by("-created_at")[:6]
+        )
+
+        user_products = []
+        user_products_count = 0
+        user_points = 0
+
+        if request.user and request.user.is_authenticated:
+            user_qs = (
+                Products.objects
+                .select_related("category", "seller")
+                .filter(seller=request.user)
+                .order_by("-created_at")
+            )
+            user_products_count = user_qs.count()
+            user_products = user_qs[:3]
+            user_points = getattr(request.user, "points", 0)
+
+        data = {
+            "recent_products": ProductListSerializer(
+                recent_products, many=True
+            ).data,
+            "user_products": ProductListSerializer(
+                user_products, many=True
+            ).data,
+            "user_products_count": user_products_count,
+            "active_transactions_count": 0,
+            "gamification": {
+                "points": user_points,
+                "badges_count": 0,
+            },
+        }
+
+        return Response(data, status=status.HTTP_200_OK)

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "clsx": "^2.1.0",
+        "lucide-react": "^0.577.0",
         "next": "^14.2.35",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -1462,6 +1463,15 @@
       },
       "bin": {
         "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.577.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.577.0.tgz",
+      "integrity": "sha512-4LjoFv2eEPwYDPg/CUdBJQSDfPyzXCRrVW1X7jrx/trgxnxkHFjnVZINbzvzxjN70dxychOfg+FTYwBiS3pQ5A==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/merge2": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,8 @@
     "format": "prettier --write \"src/**/*.{ts,tsx,json,css}\""
   },
   "dependencies": {
-     "clsx": "^2.1.0",
+    "clsx": "^2.1.0",
+    "lucide-react": "^0.577.0",
     "next": "^14.2.35",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,17 +1,24 @@
 import type { Metadata } from 'next';
+import { Inter } from 'next/font/google';
 import './globals.css';
 import { AuthProvider } from '@/hooks/useAuth';
 import Navbar from '@/components/layout/Navbar';
 
+const inter = Inter({
+  subsets: ['latin'],
+  variable: '--font-inter',
+  display: 'swap',
+});
+
 export const metadata: Metadata = {
   title: 'ReUseITESO',
-  description: 'Plataforma compraventa de artículos de segunda mano para estudiantes del ITESO',
+  description: 'Plataforma de reuso de articulos para la comunidad ITESO',
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="es">
-      <body className="bg-gray-50 text-gray-900">
+    <html lang="es" className={inter.variable}>
+      <body className="bg-slate-50 font-sans text-slate-900 antialiased">
         <AuthProvider>
           <Navbar />
           <main className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -2,43 +2,44 @@
 
 import Link from 'next/link';
 import { useAuth } from '@/hooks/useAuth';
+import Dashboard from '@/components/dashboard/Dashboard';
 
 export default function HomePage() {
   const { isAuthenticated, isLoading } = useAuth();
 
+  if (isLoading) {
+    return (
+      <main className="flex min-h-[calc(100vh-4rem)] items-center justify-center">
+        <div className="h-10 w-40 animate-pulse rounded-lg bg-slate-200" />
+      </main>
+    );
+  }
+
+  if (isAuthenticated) {
+    return <Dashboard />;
+  }
+
   return (
     <main className="flex min-h-[calc(100vh-4rem)] flex-col items-center justify-center gap-6 p-8">
-      <h1 className="text-4xl font-bold text-gray-900 sm:text-5xl">ReUseITESO</h1>
-      <p className="max-w-lg text-center text-lg text-gray-600">
+      <h1 className="text-4xl font-bold text-slate-900 sm:text-5xl">ReUseITESO</h1>
+      <p className="max-w-lg text-center text-lg text-slate-600">
         Plataforma de compraventa de segunda mano para la comunidad ITESO.
-        Publica, intercambia y dona artículos de forma segura.
+        Publica, intercambia y dona articulos de forma segura.
       </p>
-
-      {isLoading ? (
-        <div className="h-10 w-40 animate-pulse rounded-lg bg-gray-200" />
-      ) : isAuthenticated ? (
+      <div className="flex flex-col items-center gap-3 sm:flex-row">
         <Link
-          href="/products"
-          className="rounded-lg bg-blue-600 px-6 py-3 font-medium text-white transition-colors hover:bg-blue-700"
+          href="/auth/signin"
+          className="rounded-xl bg-iteso-800 px-6 py-3 font-medium text-white transition-colors hover:bg-iteso-700"
         >
-          Ver productos
+          Iniciar sesion
         </Link>
-      ) : (
-        <div className="flex flex-col items-center gap-3 sm:flex-row">
-          <Link
-            href="/auth/signin"
-            className="rounded-lg bg-blue-600 px-6 py-3 font-medium text-white transition-colors hover:bg-blue-700"
-          >
-            Iniciar sesión
-          </Link>
-          <Link
-            href="/auth/signup"
-            className="rounded-lg border border-blue-600 px-6 py-3 font-medium text-blue-600 transition-colors hover:bg-blue-50"
-          >
-            Crear cuenta
-          </Link>
-        </div>
-      )}
+        <Link
+          href="/auth/signup"
+          className="rounded-xl border border-iteso-800 px-6 py-3 font-medium text-iteso-800 transition-colors hover:bg-iteso-50"
+        >
+          Crear cuenta
+        </Link>
+      </div>
     </main>
   );
 }

--- a/frontend/src/components/dashboard/Dashboard.tsx
+++ b/frontend/src/components/dashboard/Dashboard.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import { useAuth } from '@/hooks/useAuth';
+import { useDashboard } from '@/hooks/useDashboard';
+
+import WelcomeHeader from '@/components/dashboard/WelcomeHeader';
+import QuickActions from '@/components/dashboard/QuickActions';
+import StatsSummary from '@/components/dashboard/StatsSummary';
+import MyListings from '@/components/dashboard/MyListings';
+import RecentProducts from '@/components/dashboard/RecentProducts';
+
+export default function Dashboard() {
+  const { isAuthenticated } = useAuth();
+  const { data, isLoading, error, refetch } = useDashboard();
+
+  return (
+    <div className="space-y-8 py-8">
+      <WelcomeHeader />
+      <QuickActions />
+
+      {isAuthenticated && <StatsSummary data={data} isLoading={isLoading} />}
+
+      <MyListings
+        products={data?.user_products ?? []}
+        totalCount={data?.user_products_count ?? 0}
+        isLoading={isLoading}
+        isAuthenticated={isAuthenticated}
+      />
+
+      <RecentProducts
+        products={data?.recent_products ?? []}
+        isLoading={isLoading}
+        error={error}
+        onRetry={refetch}
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/dashboard/MyListings.tsx
+++ b/frontend/src/components/dashboard/MyListings.tsx
@@ -1,0 +1,72 @@
+import Link from 'next/link';
+import { ArrowRight } from 'lucide-react';
+
+import ProductCard from '@/components/products/ProductCard';
+
+import type { Product } from '@/types/product';
+
+interface MyListingsProps {
+  products: Product[];
+  totalCount: number;
+  isLoading: boolean;
+  isAuthenticated: boolean;
+}
+
+export default function MyListings({
+  products,
+  totalCount,
+  isLoading,
+  isAuthenticated,
+}: MyListingsProps) {
+  if (!isAuthenticated) return null;
+
+  return (
+    <section>
+      <div className="mb-4 flex items-center justify-between">
+        <h2 className="text-lg font-semibold text-slate-900">Mis publicaciones</h2>
+        {totalCount > 3 && (
+          <Link
+            href="/products/my"
+            className="flex items-center gap-1 text-sm font-medium text-iteso-600 transition-colors hover:text-iteso-700"
+          >
+            Ver todas ({totalCount})
+            <ArrowRight className="h-4 w-4" />
+          </Link>
+        )}
+      </div>
+
+      {isLoading && (
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {[1, 2, 3].map(i => (
+            <div key={i} className="rounded-2xl border border-slate-200 bg-white p-4">
+              <div className="mb-3 h-44 w-full animate-pulse rounded-xl bg-slate-200" />
+              <div className="mb-2 h-4 w-20 animate-pulse rounded bg-slate-200" />
+              <div className="mb-2 h-5 w-full animate-pulse rounded bg-slate-200" />
+              <div className="h-5 w-16 animate-pulse rounded bg-slate-200" />
+            </div>
+          ))}
+        </div>
+      )}
+
+      {!isLoading && products.length === 0 && (
+        <div className="flex flex-col items-center gap-4 rounded-2xl border border-dashed border-slate-300 bg-slate-50 p-8 text-center">
+          <p className="text-sm text-slate-500">Aun no has publicado nada</p>
+          <Link
+            href="/products/new"
+            className="rounded-xl bg-iteso-800 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-iteso-700"
+          >
+            Publicar mi primer item
+          </Link>
+        </div>
+      )}
+
+      {!isLoading && products.length > 0 && (
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {products.map(product => (
+            <ProductCard key={product.id} product={product} />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/components/dashboard/QuickActions.tsx
+++ b/frontend/src/components/dashboard/QuickActions.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import Link from 'next/link';
+import { Plus, Search, Package } from 'lucide-react';
+
+import { useAuth } from '@/hooks/useAuth';
+
+const ACTIONS = [
+  {
+    href: '/products/new',
+    icon: Plus,
+    label: 'Publicar item',
+    description: 'Comparte algo con la comunidad',
+    color: 'text-iteso-600',
+    hoverBg: 'hover:bg-iteso-50',
+    iconBg: 'bg-iteso-100',
+  },
+  {
+    href: '/products',
+    icon: Search,
+    label: 'Explorar marketplace',
+    description: 'Encuentra lo que necesitas',
+    color: 'text-emerald-600',
+    hoverBg: 'hover:bg-emerald-50',
+    iconBg: 'bg-emerald-100',
+  },
+  {
+    href: '/products/my',
+    icon: Package,
+    label: 'Mis publicaciones',
+    description: 'Administra tus items',
+    color: 'text-amber-600',
+    hoverBg: 'hover:bg-amber-50',
+    iconBg: 'bg-amber-100',
+  },
+] as const;
+
+export default function QuickActions() {
+  const { isAuthenticated } = useAuth();
+
+  if (!isAuthenticated) return null;
+
+  return (
+    <div className="grid gap-4 sm:grid-cols-3">
+      {ACTIONS.map(action => {
+        const Icon = action.icon;
+        return (
+          <Link
+            key={action.href}
+            href={action.href}
+            className={`group flex items-center gap-4 rounded-2xl border border-slate-200 bg-white p-4 shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:shadow-md ${action.hoverBg}`}
+          >
+            <div
+              className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-xl ${action.iconBg} transition-transform duration-200 group-hover:scale-110`}
+            >
+              <Icon className={`h-5 w-5 ${action.color}`} />
+            </div>
+            <div>
+              <p className="text-sm font-semibold text-slate-900">{action.label}</p>
+              <p className="text-xs text-slate-500">{action.description}</p>
+            </div>
+          </Link>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/src/components/dashboard/RecentProducts.tsx
+++ b/frontend/src/components/dashboard/RecentProducts.tsx
@@ -1,0 +1,74 @@
+import Link from 'next/link';
+import { ArrowRight } from 'lucide-react';
+
+import ProductCard from '@/components/products/ProductCard';
+
+import type { Product } from '@/types/product';
+
+interface RecentProductsProps {
+  products: Product[];
+  isLoading: boolean;
+  error: string | null;
+  onRetry: () => void;
+}
+
+export default function RecentProducts({
+  products,
+  isLoading,
+  error,
+  onRetry,
+}: RecentProductsProps) {
+  return (
+    <section>
+      <div className="mb-4 flex items-center justify-between">
+        <h2 className="text-lg font-semibold text-slate-900">Lo mas reciente</h2>
+        <Link
+          href="/products"
+          className="flex items-center gap-1 text-sm font-medium text-iteso-600 transition-colors hover:text-iteso-700"
+        >
+          Ver todos
+          <ArrowRight className="h-4 w-4" />
+        </Link>
+      </div>
+
+      {isLoading && (
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {[1, 2, 3, 4, 5, 6].map(i => (
+            <div key={i} className="rounded-2xl border border-slate-200 bg-white p-4">
+              <div className="mb-3 h-44 w-full animate-pulse rounded-xl bg-slate-200" />
+              <div className="mb-2 h-4 w-20 animate-pulse rounded bg-slate-200" />
+              <div className="mb-2 h-5 w-full animate-pulse rounded bg-slate-200" />
+              <div className="h-5 w-16 animate-pulse rounded bg-slate-200" />
+            </div>
+          ))}
+        </div>
+      )}
+
+      {error && (
+        <div className="flex flex-col items-center gap-3 rounded-2xl border border-red-200 bg-red-50 p-6 text-center">
+          <p className="text-sm text-red-700">{error}</p>
+          <button
+            onClick={onRetry}
+            className="rounded-xl bg-red-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-red-700"
+          >
+            Reintentar
+          </button>
+        </div>
+      )}
+
+      {!isLoading && !error && products.length > 0 && (
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {products.map(product => (
+            <ProductCard key={product.id} product={product} />
+          ))}
+        </div>
+      )}
+
+      {!isLoading && !error && products.length === 0 && (
+        <p className="py-8 text-center text-sm text-slate-500">
+          No hay productos publicados todavia
+        </p>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/components/dashboard/StatsSummary.tsx
+++ b/frontend/src/components/dashboard/StatsSummary.tsx
@@ -1,0 +1,74 @@
+import { Package, ArrowLeftRight, Award } from 'lucide-react';
+
+import type { DashboardData } from '@/types/dashboard';
+
+interface StatsSummaryProps {
+  data: DashboardData | null;
+  isLoading: boolean;
+}
+
+export default function StatsSummary({ data, isLoading }: StatsSummaryProps) {
+  if (isLoading) {
+    return (
+      <div className="grid gap-4 sm:grid-cols-3">
+        {[1, 2, 3].map(i => (
+          <div key={i} className="rounded-2xl border border-slate-200 bg-white p-5">
+            <div className="mb-2 h-8 w-16 animate-pulse rounded bg-slate-200" />
+            <div className="h-4 w-24 animate-pulse rounded bg-slate-200" />
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  if (!data) return null;
+
+  const stats = [
+    {
+      value: data.user_products_count,
+      label: 'Mis publicaciones',
+      icon: Package,
+      borderColor: 'border-l-iteso-500',
+      textColor: 'text-iteso-600',
+      iconColor: 'text-iteso-400',
+    },
+    {
+      value: data.active_transactions_count,
+      label: 'Transacciones activas',
+      icon: ArrowLeftRight,
+      borderColor: 'border-l-emerald-500',
+      textColor: 'text-emerald-600',
+      iconColor: 'text-emerald-400',
+    },
+    {
+      value: data.gamification.points,
+      label: 'Puntos',
+      icon: Award,
+      borderColor: 'border-l-amber-400',
+      textColor: 'text-amber-600',
+      iconColor: 'text-amber-400',
+    },
+  ];
+
+  return (
+    <div className="grid gap-4 sm:grid-cols-3">
+      {stats.map(stat => {
+        const Icon = stat.icon;
+        return (
+          <div
+            key={stat.label}
+            className={`rounded-2xl border border-slate-200 border-l-4 ${stat.borderColor} bg-white p-5 shadow-sm`}
+          >
+            <div className="flex items-center justify-between">
+              <p className={`text-3xl font-bold tracking-tight ${stat.textColor}`}>
+                {stat.value}
+              </p>
+              <Icon className={`h-5 w-5 ${stat.iconColor}`} />
+            </div>
+            <p className="mt-1 text-sm text-slate-500">{stat.label}</p>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/src/components/dashboard/WelcomeHeader.tsx
+++ b/frontend/src/components/dashboard/WelcomeHeader.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import { Recycle } from 'lucide-react';
+
+import { useAuth } from '@/hooks/useAuth';
+
+export default function WelcomeHeader() {
+  const { user, isAuthenticated } = useAuth();
+
+  return (
+    <div className="relative overflow-hidden rounded-2xl bg-gradient-to-br from-iteso-900 to-iteso-700 p-6 text-white sm:p-8">
+      <div className="relative z-10">
+        <h1 className="text-2xl font-bold tracking-tight sm:text-3xl">
+          {isAuthenticated ? `Hola, ${user?.first_name}` : 'Bienvenido a ReUseITESO'}
+        </h1>
+        <p className="mt-1 text-sm text-white/70 sm:text-base">
+          {isAuthenticated
+            ? 'Esto es lo nuevo en la comunidad ITESO'
+            : 'Inicia sesion para ver tu dashboard personalizado'}
+        </p>
+        <div className="mt-3 h-0.5 w-16 rounded-full bg-red-500" />
+      </div>
+      <Recycle
+        className="absolute -bottom-4 -right-4 h-32 w-32 text-white/5 sm:h-40 sm:w-40"
+        strokeWidth={1}
+      />
+    </div>
+  );
+}

--- a/frontend/src/hooks/useDashboard.ts
+++ b/frontend/src/hooks/useDashboard.ts
@@ -1,0 +1,33 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+import { apiClient } from '@/lib/api';
+
+import type { DashboardData } from '@/types/dashboard';
+
+export function useDashboard() {
+  const [data, setData] = useState<DashboardData | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchDashboard = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const response = await apiClient<DashboardData>('/auth/dashboard/');
+      setData(response);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Error al cargar el dashboard';
+      setError(message);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchDashboard();
+  }, [fetchDashboard]);
+
+  return { data, isLoading, error, refetch: fetchDashboard };
+}

--- a/frontend/src/types/dashboard.ts
+++ b/frontend/src/types/dashboard.ts
@@ -1,0 +1,14 @@
+import type { Product } from '@/types/product';
+
+export interface GamificationSummary {
+  points: number;
+  badges_count: number;
+}
+
+export interface DashboardData {
+  recent_products: Product[];
+  user_products: Product[];
+  user_products_count: number;
+  active_transactions_count: number;
+  gamification: GamificationSummary;
+}

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -2,7 +2,26 @@
 module.exports = {
   content: ['./src/**/*.{js,ts,jsx,tsx,mdx}'],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        iteso: {
+          50: '#EFF6FF',
+          100: '#DBEAFE',
+          200: '#BFDBFE',
+          300: '#93C5FD',
+          400: '#60A5FA',
+          500: '#3B7CB8',
+          600: '#2D6498',
+          700: '#244F7A',
+          800: '#1B3A5C',
+          900: '#0F2A4A',
+          950: '#0A1E35',
+        },
+      },
+      fontFamily: {
+        sans: ['var(--font-inter)', 'system-ui', 'sans-serif'],
+      },
+    },
   },
   plugins: [],
 };


### PR DESCRIPTION
```
## 📌 Summary

Implements HU-CORE-04: home dashboard with recent activity. Adds a DashboardView endpoint (GET /api/auth/dashboard/) that aggregates recent products, user listings, and placeholder data for transactions and gamification. Replaces the placeholder home page with a full dashboard that only shows after login. Also introduces the ITESO navy design system (custom color palette, Inter font, lucide-react icons) and updates the layout accordingly.

---

## 🔍 Type of Change

- [x] Feature (new functionality)
- [ ] Bug fix
- [ ] Agent (development tooling)
- [ ] Documentation
- [ ] Refactor / cleanup
- [ ] CI / DevOps

---

## 🧩 Scope

- [x] Backend
- [x] Frontend
- [ ] Agents
- [ ] Docs
- [ ] CI / Infrastructure

---

## 🤖 Agent Details (if applicable)

N/A

---

## 🧪 Testing

- [x] Local execution
- [x] Manual testing
- [ ] Unit tests
- [ ] Not applicable (explain why)

Frontend builds successfully with next build (0 TypeScript errors). Landing page shows sign in / sign up buttons when not authenticated. Dashboard renders after login with all 5 sections. Verified error state and loading skeletons when backend is not running.

---

## 📎 Related Context

- User Story: HU-CORE-04 - User can view the home dashboard with recent activity
- Uses existing ProductListSerializer and JWT auth from dev branch
- Transactions count and gamification points return 0 until those modules implement their endpoints
- New dependency: lucide-react for icons
- Dashboard endpoint registered under /api/auth/dashboard/ alongside existing auth routes

---

## ✅ Checklist

- [x] Code builds and runs locally
- [x] Changes are small and focused
- [x] Code follows agreed standards
- [x] Documentation was updated if needed
- [x] No unrelated changes are included
- [x] AI-generated content was reviewed and understood

---

## 📝 Notes for Reviewers

The home page now has two states: unauthenticated users see the landing with sign in/sign up buttons, authenticated users see the full dashboard. This uses the existing useAuth hook from dev.

ITESO design system introduces a custom color palette (iteso-50 to iteso-950) in tailwind.config.js and Inter font via next/font. The layout.tsx was updated to use these but the Navbar component was not modified.

Transactions and gamification are placeholders in the DashboardView. When those teams finish their endpoints, only core/views.py needs updating.

The DashboardView uses AllowAny permission so it works for both authenticated and unauthenticated users, returning different data depending on auth state.
## CI Failures - Pre-existing issues in dev

The 3 failing CI jobs are NOT caused by this PR. They are pre-existing issues in the dev branch:

1. **Backend Checks (Ruff):** 120 lint errors, mostly in `backend/gamification/services/point_service.py` (B904 exception chaining) and missing trailing newlines across multiple files. None of these files were modified in this PR.

2. **Frontend Checks (ESLint):** ESLint v10 is incompatible with the current `eslint-config-next: ^0.2.4`. This is a dependency version mismatch that existed in dev before this PR. My changes do not modify ESLint config or linting dependencies.

3. **CI Gate:** Fails automatically because Backend and Frontend checks failed. No action needed on this job.

My PR only modifies `core/views.py`, `core/urls.py`, `tailwind.config.js`, `layout.tsx`, `page.tsx`, and adds new dashboard components. The frontend builds successfully with `next build` (0 errors).

```