### PR TITLE
Added rate limiting to user, email, auth, and anon endpoints

### DIFF
--- a/backend/config/exception_handler.py
+++ b/backend/config/exception_handler.py
@@ -1,10 +1,15 @@
+import logging
+
 from rest_framework.exceptions import (
     AuthenticationFailed,
     NotFound,
     PermissionDenied,
+    Throttled,
     ValidationError,
 )
 from rest_framework.views import exception_handler
+
+logger = logging.getLogger(__name__)
 
 
 def custom_exception_handler(exc, context):
@@ -13,7 +18,17 @@ def custom_exception_handler(exc, context):
     if response is not None:
         error_code = "SERVER_ERROR"
 
-        if isinstance(exc, ValidationError):
+        if isinstance(exc, Throttled):
+            error_code = "RATE_LIMIT_EXCEEDED"
+            request = context.get("request")
+            logger.warning(
+                "rate_limit_exceeded path=%s method=%s user=%s ip=%s",
+                request.path if request else "unknown",
+                request.method if request else "unknown",
+                str(request.user) if request else "unknown",
+                request.META.get("REMOTE_ADDR", "unknown") if request else "unknown",
+            )
+        elif isinstance(exc, ValidationError):
             error_code = "VALIDATION_ERROR"
         elif isinstance(exc, AuthenticationFailed):
             error_code = "AUTHENTICATION_ERROR"
@@ -22,14 +37,19 @@ def custom_exception_handler(exc, context):
         elif isinstance(exc, NotFound):
             error_code = "NOT_FOUND"
 
-        custom_response_data = {
+        wait = getattr(exc, "wait", None)
+        message = (
+            f"Demasiadas solicitudes. Intenta de nuevo en {int(wait)} segundos."
+            if isinstance(exc, Throttled) and wait
+            else str(exc)
+        )
+
+        response.data = {
             "error": {
                 "code": error_code,
-                "message": str(exc),
+                "message": message,
                 "details": response.data if isinstance(response.data, dict) else {},
             }
         }
-
-        response.data = custom_response_data
 
     return response

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -115,6 +115,13 @@ AUTHENTICATION_BACKENDS = [
     "core.backends.EmailBackend",
 ]
 
+CACHES = {
+    "default": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "LOCATION": "reuse-rate-limit",
+    }
+}
+
 REST_FRAMEWORK = {
     "DEFAULT_AUTHENTICATION_CLASSES": [
         "rest_framework_simplejwt.authentication.JWTAuthentication",
@@ -122,6 +129,16 @@ REST_FRAMEWORK = {
     "DEFAULT_PERMISSION_CLASSES": [
         "rest_framework.permissions.IsAuthenticatedOrReadOnly",
     ],
+    "DEFAULT_THROTTLE_CLASSES": [
+        "core.throttles.StandardAnonThrottle",
+        "core.throttles.StandardUserThrottle",
+    ],
+    "DEFAULT_THROTTLE_RATES": {
+        "anon": "100/hour",
+        "user": "1000/hour",
+        "auth": "5/minute",
+        "email_verification": "3/minute",
+    },
     "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.PageNumberPagination",
     "PAGE_SIZE": 20,
     "DEFAULT_FILTER_BACKENDS": [

--- a/backend/core/throttles.py
+++ b/backend/core/throttles.py
@@ -1,0 +1,31 @@
+from rest_framework.throttling import AnonRateThrottle, SimpleRateThrottle, UserRateThrottle
+
+
+class AuthRateThrottle(SimpleRateThrottle):
+    scope = "auth"
+
+    def get_cache_key(self, request, view):
+        ident = (
+            request.META.get("HTTP_X_FORWARDED_FOR", "").split(",")[0].strip()
+            or request.META.get("REMOTE_ADDR", "")
+        )
+        return self.cache_format % {"scope": self.scope, "ident": ident}
+
+
+class EmailVerificationRateThrottle(SimpleRateThrottle):
+    scope = "email_verification"
+
+    def get_cache_key(self, request, view):
+        ident = (
+            request.META.get("HTTP_X_FORWARDED_FOR", "").split(",")[0].strip()
+            or request.META.get("REMOTE_ADDR", "")
+        )
+        return self.cache_format % {"scope": self.scope, "ident": ident}
+
+
+class StandardAnonThrottle(AnonRateThrottle):
+    scope = "anon"
+
+
+class StandardUserThrottle(UserRateThrottle):
+    scope = "user"

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -13,6 +13,7 @@ from rest_framework.views import APIView
 from rest_framework_simplejwt.exceptions import TokenError
 from rest_framework_simplejwt.tokens import RefreshToken
 
+from core.throttles import AuthRateThrottle, EmailVerificationRateThrottle
 from .models.email_verification import EmailVerificationToken
 from .serializers import SignInSerializer, SignUpSerializer, UserProfileSerializer
 
@@ -107,6 +108,7 @@ class SignUpView(generics.CreateAPIView):
 
     serializer_class = SignUpSerializer
     permission_classes = [AllowAny]
+    throttle_classes = [AuthRateThrottle]
 
     # Cambios realizados para mandar el tocken con verificacion al correo
     def create(self, request, *args, **kwargs):
@@ -143,6 +145,7 @@ class SignInView(APIView):
     """
 
     permission_classes = [AllowAny]
+    throttle_classes = [AuthRateThrottle]
 
     def post(self, request):
         serializer = SignInSerializer(data=request.data)
@@ -263,6 +266,7 @@ class EmailVerificationSendView(APIView):
     """
 
     permission_classes = [AllowAny]
+    throttle_classes = [EmailVerificationRateThrottle]
 
     def post(self, request):
         email = (request.data.get("email") or "").strip().lower()

--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -53,6 +53,11 @@ async function authFetch<T>(endpoint: string, options?: RequestInit): Promise<T>
     }
   }
 
+  if (response.status === 429) {
+    const body = await response.json().catch(() => null);
+    throw new Error(body?.error?.message ?? 'Demasiadas solicitudes. Espera un momento antes de intentar de nuevo.');
+  }
+
   if (!response.ok) {
     const body = await response.json().catch(() => null);
     const message = body?.error?.message ?? body?.message ?? `Error ${response.status}`;
@@ -91,6 +96,11 @@ export async function signIn(credentials: SignInRequest): Promise<AuthResponse> 
     body: JSON.stringify(credentials),
   });
 
+  if (response.status === 429) {
+    const body = await response.json().catch(() => null);
+    throw new Error(body?.error?.message ?? 'Demasiadas solicitudes. Espera un momento antes de intentar de nuevo.');
+  }
+
   if (!response.ok) {
     const body = await response.json().catch(() => null);
     const message = body?.error?.message ?? 'Correo o contraseña incorrectos.';
@@ -110,6 +120,10 @@ export async function signUp(payload: SignUpRequest): Promise<any> {
   });
 
   const body = await response.json().catch(() => ({}));
+
+  if (response.status === 429) {
+    throw new Error(body?.error?.message ?? 'Demasiadas solicitudes. Espera un momento antes de intentar de nuevo.');
+  }
 
   if (!response.ok) {
     if (body?.error?.details) {


### PR DESCRIPTION
## 📌 Summary
Implements rate limiting across the backend API to protect against brute force attacks and accidental overload. Uses DRF's built-in throttling (no new dependencies) with an IP-based strict limit on auth endpoints and broader per-user/anon limits on the rest of the API. The frontend surfaces a clear message when a user hits the limit.

---

## 🔍 Type of Change

- [x] Feature (new functionality)
- [ ] Bug fix
- [ ] Agent (development tooling)
- [ ] Documentation
- [ ] Refactor / cleanup
- [ ] CI / DevOps

---

## 🧩 Scope

- [x] Backend
- [x] Frontend
- [ ] Agents
- [ ] Docs
- [ ] CI / Infrastructure

---

## 🤖 Agent Details (if applicable)
N/A

---

## 🧪 Testing

- [x] Local execution
- [x] Manual testing
- [ ] Unit tests
- [ ] Not applicable

Tested flows:
- Sending 6+ rapid POST requests to `/api/auth/signin/` → 429 returned on the 6th
- Sending 4+ rapid POST requests to `/api/auth/email-verification/send/` → 429 on the 4th
- Normal usage (< limit) → no disruption
- Frontend displays `"Demasiadas solicitudes. Intenta de nuevo en X segundos."` on 429

---

## 📎 Related Context
HU-CORE-16

---

## ✅ Checklist

- [x] Code builds and runs locally
- [x] Changes are small and focused
- [x] Code follows agreed standards
- [x] Documentation was updated if needed
- [x] No unrelated changes are included
- [x] AI-generated content was reviewed and understood

---

## 📝 Notes for Reviewers

**Rate limits applied:**

| Scope | Limit | Endpoints |
|---|---|---|
| `auth` | 5 req/min per IP | `/signin/`, `/signup/` |
| `email_verification` | 3 req/min per IP | `/email-verification/send/` |
| `anon` | 100 req/hour per IP | All public endpoints |
| `user` | 1000 req/hour per user | All authenticated endpoints |

Auth throttles are **IP-based** (not user-based) because brute force happens before authentication.

Cache backend is `LocMemCache` for dev. For production, swap to Redis by updating `CACHES` in `settings.py` — no code changes required.

Rate limit events are logged as `WARNING` via Django's logging system with path, method, user, and IP.
