### PR TITLE
feat:Add transaction reviews and history UI

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,16 @@
+# Normalize line endings
+* text=auto
+
+# Force LF for shell scripts (critical for Docker/Linux compatibility)
+*.sh text eol=lf
+
+# Force LF for Python files
+*.py text eol=lf
+
+# Binary files
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.pdf binary

--- a/backend/core/throttles.py
+++ b/backend/core/throttles.py
@@ -1,4 +1,8 @@
-from rest_framework.throttling import AnonRateThrottle, SimpleRateThrottle, UserRateThrottle
+from rest_framework.throttling import (
+    AnonRateThrottle,
+    SimpleRateThrottle,
+    UserRateThrottle,
+)
 
 
 class AuthRateThrottle(SimpleRateThrottle):

--- a/backend/core/throttles.py
+++ b/backend/core/throttles.py
@@ -9,10 +9,9 @@ class AuthRateThrottle(SimpleRateThrottle):
     scope = "auth"
 
     def get_cache_key(self, request, view):
-        ident = (
-            request.META.get("HTTP_X_FORWARDED_FOR", "").split(",")[0].strip()
-            or request.META.get("REMOTE_ADDR", "")
-        )
+        ident = request.META.get("HTTP_X_FORWARDED_FOR", "").split(",")[
+            0
+        ].strip() or request.META.get("REMOTE_ADDR", "")
         return self.cache_format % {"scope": self.scope, "ident": ident}
 
 
@@ -20,10 +19,9 @@ class EmailVerificationRateThrottle(SimpleRateThrottle):
     scope = "email_verification"
 
     def get_cache_key(self, request, view):
-        ident = (
-            request.META.get("HTTP_X_FORWARDED_FOR", "").split(",")[0].strip()
-            or request.META.get("REMOTE_ADDR", "")
-        )
+        ident = request.META.get("HTTP_X_FORWARDED_FOR", "").split(",")[
+            0
+        ].strip() or request.META.get("REMOTE_ADDR", "")
         return self.cache_format % {"scope": self.scope, "ident": ident}
 
 

--- a/backend/core/urls.py
+++ b/backend/core/urls.py
@@ -22,10 +22,12 @@ urlpatterns = [
         views.EmailVerificationConfirmView.as_view(),
         name="email_verification_confirm",
     ),
-
     # HU-CORE-04: Dashboard
     path("dashboard/", views.DashboardView.as_view(), name="dashboard"),
-
     # HU-CORE-10: Profile picture upload
-    path("profile/upload-picture/", views.ProfilePictureUploadView.as_view(), name="profile-upload-picture"),
+    path(
+        "profile/upload-picture/",
+        views.ProfilePictureUploadView.as_view(),
+        name="profile-upload-picture",
+    ),
 ]

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -412,12 +412,22 @@ class ProfilePictureUploadView(APIView):
         file = request.FILES.get("file")
         if not file:
             return Response(
-                {"error": {"code": "NO_FILE", "message": "No se envio ningun archivo."}},
+                {
+                    "error": {
+                        "code": "NO_FILE",
+                        "message": "No se envio ningun archivo.",
+                    }
+                },
                 status=status.HTTP_400_BAD_REQUEST,
             )
         if file.content_type not in self.ALLOWED_TYPES:
             return Response(
-                {"error": {"code": "INVALID_TYPE", "message": "Solo imagenes (JPEG, PNG, WebP, GIF)."}},
+                {
+                    "error": {
+                        "code": "INVALID_TYPE",
+                        "message": "Solo imagenes (JPEG, PNG, WebP, GIF).",
+                    }
+                },
                 status=status.HTTP_400_BAD_REQUEST,
             )
         if file.size > self.MAX_SIZE:

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -16,10 +16,10 @@ from rest_framework.views import APIView
 from rest_framework_simplejwt.exceptions import TokenError
 from rest_framework_simplejwt.tokens import RefreshToken
 
+from core.throttles import AuthRateThrottle, EmailVerificationRateThrottle
 from marketplace.models import Products
 from marketplace.serializers.product import ProductListSerializer
 
-from core.throttles import AuthRateThrottle, EmailVerificationRateThrottle
 from .models.email_verification import EmailVerificationToken
 from .serializers import SignInSerializer, SignUpSerializer, UserProfileSerializer
 

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -1,5 +1,7 @@
 import hashlib
+import os
 import secrets
+import uuid
 from datetime import timedelta
 
 from django.conf import settings
@@ -7,11 +9,15 @@ from django.contrib.auth import authenticate, get_user_model
 from django.core.mail import send_mail
 from django.utils import timezone
 from rest_framework import generics, status
+from rest_framework.parsers import MultiPartParser
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
 from rest_framework_simplejwt.exceptions import TokenError
 from rest_framework_simplejwt.tokens import RefreshToken
+
+from marketplace.models import Products
+from marketplace.serializers.product import ProductListSerializer
 
 from .models.email_verification import EmailVerificationToken
 from .serializers import SignInSerializer, SignUpSerializer, UserProfileSerializer
@@ -345,9 +351,6 @@ class EmailVerificationConfirmView(APIView):
 
 # ── Dashboard (HU-CORE-04) ───────────────────────────────
 
-from marketplace.models import Products
-from marketplace.serializers.product import ProductListSerializer
-
 
 class DashboardView(APIView):
     """GET /api/auth/dashboard/ — aggregated home dashboard data."""
@@ -390,10 +393,6 @@ class DashboardView(APIView):
 
 
 # ── Profile Picture Upload (HU-CORE-10) ─────────────────
-
-from rest_framework.parsers import MultiPartParser
-import os
-import uuid
 
 
 class ProfilePictureUploadView(APIView):

--- a/backend/marketplace/models/__init__.py
+++ b/backend/marketplace/models/__init__.py
@@ -5,12 +5,14 @@ from .product import Products
 from .product_reaction import ProductReaction
 from .report import Report
 from .transaction import Transaction
+from .transaction_review import TransactionReview
 
 __all__ = [
     "Category",
     "Products",
     "Images",
     "Transaction",
+    "TransactionReview",
     "ForumQuestion",
     "ProductReaction",
     "Report",

--- a/backend/marketplace/models/transaction_review.py
+++ b/backend/marketplace/models/transaction_review.py
@@ -1,0 +1,37 @@
+from django.core.validators import MaxValueValidator, MinValueValidator
+from django.db import models
+
+
+class TransactionReview(models.Model):
+    transaction = models.ForeignKey(
+        "marketplace.Transaction",
+        on_delete=models.CASCADE,
+        related_name="reviews",
+    )
+    reviewer = models.ForeignKey(
+        "core.User",
+        on_delete=models.CASCADE,
+        related_name="reviews_given",
+    )
+    reviewee = models.ForeignKey(
+        "core.User",
+        on_delete=models.CASCADE,
+        related_name="reviews_received",
+    )
+    rating = models.PositiveSmallIntegerField(
+        validators=[MinValueValidator(1), MaxValueValidator(5)],
+    )
+    comment = models.TextField(blank=True, default="")
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        constraints = [
+            models.UniqueConstraint(
+                fields=["transaction", "reviewer"],
+                name="uq_transaction_review_reviewer",
+            )
+        ]
+        ordering = ["-created_at"]
+
+    def __str__(self) -> str:
+        return f"Review by {self.reviewer_id} on tx {self.transaction_id}: {self.rating}/5"

--- a/backend/marketplace/models/transaction_review.py
+++ b/backend/marketplace/models/transaction_review.py
@@ -34,4 +34,6 @@ class TransactionReview(models.Model):
         ordering = ["-created_at"]
 
     def __str__(self) -> str:
-        return f"Review by {self.reviewer_id} on tx {self.transaction_id}: {self.rating}/5"
+        return (
+            f"Review by {self.reviewer_id} on tx {self.transaction_id}: {self.rating}/5"
+        )

--- a/backend/marketplace/serializers/__init__.py
+++ b/backend/marketplace/serializers/__init__.py
@@ -9,9 +9,11 @@ from .product import (
 from .product_detail import ProductDetailSerializer
 from .transaction import (
     TransactionCreateSerializer,
+    TransactionHistorySerializer,
     TransactionSerializer,
     TransactionStatusSerializer,
 )
+from .transaction_review import TransactionReviewCreateSerializer, TransactionReviewSerializer
 
 __all__ = [
     "CategorySerializer",
@@ -24,4 +26,7 @@ __all__ = [
     "TransactionCreateSerializer",
     "TransactionSerializer",
     "TransactionStatusSerializer",
+    "TransactionHistorySerializer",
+    "TransactionReviewSerializer",
+    "TransactionReviewCreateSerializer",
 ]

--- a/backend/marketplace/serializers/__init__.py
+++ b/backend/marketplace/serializers/__init__.py
@@ -13,7 +13,10 @@ from .transaction import (
     TransactionSerializer,
     TransactionStatusSerializer,
 )
-from .transaction_review import TransactionReviewCreateSerializer, TransactionReviewSerializer
+from .transaction_review import (
+    TransactionReviewCreateSerializer,
+    TransactionReviewSerializer,
+)
 
 __all__ = [
     "CategorySerializer",

--- a/backend/marketplace/serializers/transaction.py
+++ b/backend/marketplace/serializers/transaction.py
@@ -6,6 +6,7 @@ from rest_framework import serializers
 from core.models import User
 from marketplace.models import Products, Transaction, TransactionReview
 from marketplace.serializers.category import CategorySerializer
+from marketplace.serializers.transaction_review import TransactionReviewSerializer
 from marketplace.services.transaction_service import (
     UPDATABLE_TRANSACTION_STATUSES,
     get_expiration_datetime,
@@ -107,17 +108,6 @@ class TransactionStatusSerializer(serializers.Serializer):
     status = serializers.ChoiceField(choices=UPDATABLE_TRANSACTION_STATUSES)
 
 
-class TransactionReviewReadSerializer(serializers.ModelSerializer):
-    reviewer_name = serializers.SerializerMethodField()
-
-    def get_reviewer_name(self, obj):
-        return f"{obj.reviewer.first_name} {obj.reviewer.last_name}".strip()
-
-    class Meta:
-        model = TransactionReview
-        fields = ["id", "rating", "comment", "reviewer_name", "created_at"]
-
-
 class TransactionHistorySerializer(TransactionSerializer):
     """TransactionSerializer extended with review fields for the history endpoint."""
 
@@ -140,7 +130,7 @@ class TransactionHistorySerializer(TransactionSerializer):
             return None
         try:
             review = TransactionReview.objects.get(transaction=obj, reviewer=request.user)
-            return TransactionReviewReadSerializer(review).data
+            return TransactionReviewSerializer(review).data
         except TransactionReview.DoesNotExist:
             return None
 

--- a/backend/marketplace/serializers/transaction.py
+++ b/backend/marketplace/serializers/transaction.py
@@ -4,7 +4,7 @@ from django.utils import timezone
 from rest_framework import serializers
 
 from core.models import User
-from marketplace.models import Products, Transaction
+from marketplace.models import Products, Transaction, TransactionReview
 from marketplace.serializers.category import CategorySerializer
 from marketplace.services.transaction_service import (
     UPDATABLE_TRANSACTION_STATUSES,
@@ -105,3 +105,44 @@ class TransactionCreateSerializer(serializers.Serializer):
 
 class TransactionStatusSerializer(serializers.Serializer):
     status = serializers.ChoiceField(choices=UPDATABLE_TRANSACTION_STATUSES)
+
+
+class TransactionReviewReadSerializer(serializers.ModelSerializer):
+    reviewer_name = serializers.SerializerMethodField()
+
+    def get_reviewer_name(self, obj):
+        return f"{obj.reviewer.first_name} {obj.reviewer.last_name}".strip()
+
+    class Meta:
+        model = TransactionReview
+        fields = ["id", "rating", "comment", "reviewer_name", "created_at"]
+
+
+class TransactionHistorySerializer(TransactionSerializer):
+    """TransactionSerializer extended with review fields for the history endpoint."""
+
+    can_review = serializers.SerializerMethodField()
+    my_review = serializers.SerializerMethodField()
+
+    def get_can_review(self, obj):
+        if obj.status != "completada":
+            return False
+        request = self.context.get("request")
+        if not request or not request.user.is_authenticated:
+            return False
+        return not TransactionReview.objects.filter(
+            transaction=obj, reviewer=request.user
+        ).exists()
+
+    def get_my_review(self, obj):
+        request = self.context.get("request")
+        if not request or not request.user.is_authenticated:
+            return None
+        try:
+            review = TransactionReview.objects.get(transaction=obj, reviewer=request.user)
+            return TransactionReviewReadSerializer(review).data
+        except TransactionReview.DoesNotExist:
+            return None
+
+    class Meta(TransactionSerializer.Meta):
+        fields = TransactionSerializer.Meta.fields + ["can_review", "my_review"]

--- a/backend/marketplace/serializers/transaction.py
+++ b/backend/marketplace/serializers/transaction.py
@@ -98,9 +98,7 @@ class TransactionCreateSerializer(serializers.Serializer):
 
     def validate_delivery_date(self, value):
         if value <= timezone.now():
-            raise serializers.ValidationError(
-                "La fecha de entrega debe ser futura."
-            )
+            raise serializers.ValidationError("La fecha de entrega debe ser futura.")
         return value
 
 
@@ -129,7 +127,9 @@ class TransactionHistorySerializer(TransactionSerializer):
         if not request or not request.user.is_authenticated:
             return None
         try:
-            review = TransactionReview.objects.get(transaction=obj, reviewer=request.user)
+            review = TransactionReview.objects.get(
+                transaction=obj, reviewer=request.user
+            )
             return TransactionReviewSerializer(review).data
         except TransactionReview.DoesNotExist:
             return None

--- a/backend/marketplace/serializers/transaction_review.py
+++ b/backend/marketplace/serializers/transaction_review.py
@@ -1,0 +1,26 @@
+from rest_framework import serializers
+
+from marketplace.models import TransactionReview
+
+
+class TransactionReviewSerializer(serializers.ModelSerializer):
+    reviewer_name = serializers.SerializerMethodField()
+
+    def get_reviewer_name(self, obj):
+        return obj.reviewer.get_full_name()
+
+    class Meta:
+        model = TransactionReview
+        fields = ["id", "rating", "comment", "reviewer_name", "created_at"]
+        read_only_fields = ["id", "reviewer_name", "created_at"]
+
+
+class TransactionReviewCreateSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = TransactionReview
+        fields = ["rating", "comment"]
+
+    def validate_rating(self, value):
+        if not 1 <= value <= 5:
+            raise serializers.ValidationError("La calificacion debe ser entre 1 y 5.")
+        return value

--- a/backend/marketplace/services/transaction_service.py
+++ b/backend/marketplace/services/transaction_service.py
@@ -79,8 +79,10 @@ def _reuse_cancelled_transaction(
 def create_transaction_request(product_id, buyer, delivery_location, delivery_date):
     with db_transaction.atomic():
         try:
-            product = Products.objects.select_for_update().select_related("seller").get(
-                pk=product_id
+            product = (
+                Products.objects.select_for_update()
+                .select_related("seller")
+                .get(pk=product_id)
             )
         except Products.DoesNotExist as err:
             raise StateConflictError("El producto no existe.") from err
@@ -136,11 +138,15 @@ def create_transaction_request(product_id, buyer, delivery_location, delivery_da
 
 def update_transaction_status(transaction_id, new_status, actor):
     with db_transaction.atomic():
-        transaction = Transaction.objects.select_for_update().select_related(
-            "product",
-            "seller",
-            "buyer",
-        ).get(pk=transaction_id)
+        transaction = (
+            Transaction.objects.select_for_update()
+            .select_related(
+                "product",
+                "seller",
+                "buyer",
+            )
+            .get(pk=transaction_id)
+        )
 
         actor_role = get_actor_role(transaction, actor)
 

--- a/backend/marketplace/tests/test_transactions_api.py
+++ b/backend/marketplace/tests/test_transactions_api.py
@@ -55,9 +55,9 @@ class TransactionApiTests(APITestCase):
     def _create_transaction(self, user=None, product_id=None, delivery_date=None):
         actor = user or self.buyer
         target_product_id = product_id or self.product.pk
-        target_delivery_date = delivery_date or (
-            timezone.now() + timedelta(days=1)
-        ).isoformat()
+        target_delivery_date = (
+            delivery_date or (timezone.now() + timedelta(days=1)).isoformat()
+        )
         self._auth(actor)
         return self.client.post(
             self.TRANSACTIONS_URL,

--- a/backend/marketplace/urls.py
+++ b/backend/marketplace/urls.py
@@ -3,11 +3,8 @@ from rest_framework.routers import DefaultRouter
 
 from marketplace.views import CategoryViewSet, ProductViewSet, TransactionViewSet
 
-# Crear el router y registrar los ViewSets ( los Endpoints de la API )
 router = DefaultRouter()
-# /api/products/ -> ProductViewSet
 router.register("products", ProductViewSet, basename="products")
-# /api/categories/ -> CategoryViewSet
 router.register("categories", CategoryViewSet, basename="categories")
 # /api/transactions/ -> TransactionViewSet
 router.register("transactions", TransactionViewSet, basename="transactions")

--- a/backend/marketplace/views/transaction.py
+++ b/backend/marketplace/views/transaction.py
@@ -1,3 +1,4 @@
+from django.db import IntegrityError, transaction as db_transaction
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter, extend_schema, extend_schema_view
 from rest_framework import mixins, status, viewsets
@@ -12,7 +13,10 @@ from marketplace.serializers.transaction import (
     TransactionSerializer,
     TransactionStatusSerializer,
 )
-from marketplace.serializers.transaction_review import TransactionReviewCreateSerializer
+from marketplace.serializers.transaction_review import (
+    TransactionReviewCreateSerializer,
+    TransactionReviewSerializer,
+)
 from marketplace.services.transaction_service import (
     create_transaction_request,
     list_transactions_for_user,
@@ -196,7 +200,7 @@ class TransactionViewSet(
         summary="Rate a completed transaction",
         description="Submit a 1-5 star rating and optional comment for a completed transaction. Each party can only submit one review per transaction.",
         request=TransactionReviewCreateSerializer,
-        responses={201: None},
+        responses={201: TransactionReviewSerializer},
         tags=["Marketplace > Transactions"],
     )
     @action(detail=True, methods=["post"], url_path="review")
@@ -234,10 +238,21 @@ class TransactionViewSet(
             if transaction.seller_id == request.user.id
             else transaction.seller
         )
-        TransactionReview.objects.create(
-            transaction=transaction,
-            reviewer=request.user,
-            reviewee=reviewee,
-            **serializer.validated_data,
+        try:
+            with db_transaction.atomic():
+                review = TransactionReview.objects.create(
+                    transaction=transaction,
+                    reviewer=request.user,
+                    reviewee=reviewee,
+                    **serializer.validated_data,
+                )
+        except IntegrityError:
+            return Response(
+                {"detail": "Ya calificaste esta transaccion."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        response_serializer = TransactionReviewSerializer(
+            review, context=self.get_serializer_context()
         )
-        return Response(status=status.HTTP_201_CREATED)
+        return Response(response_serializer.data, status=status.HTTP_201_CREATED)

--- a/backend/marketplace/views/transaction.py
+++ b/backend/marketplace/views/transaction.py
@@ -5,12 +5,14 @@ from rest_framework.decorators import action
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
-from marketplace.models import Transaction
+from marketplace.models import Transaction, TransactionReview
 from marketplace.serializers.transaction import (
     TransactionCreateSerializer,
+    TransactionHistorySerializer,
     TransactionSerializer,
     TransactionStatusSerializer,
 )
+from marketplace.serializers.transaction_review import TransactionReviewCreateSerializer
 from marketplace.services.transaction_service import (
     create_transaction_request,
     list_transactions_for_user,
@@ -131,3 +133,73 @@ class TransactionViewSet(
             context=self.get_serializer_context(),
         )
         return Response(response_serializer.data, status=status.HTTP_200_OK)
+
+    @extend_schema(
+        summary="Transaction history",
+        description=(
+            "Returns completed transactions for the authenticated user. "
+            "Supports filtering by transaction_type, date_from, and date_to."
+        ),
+        parameters=[
+            OpenApiParameter(name="transaction_type", type=OpenApiTypes.STR, location=OpenApiParameter.QUERY, required=False, enum=["donation", "sale", "swap"]),
+            OpenApiParameter(name="date_from", type=OpenApiTypes.DATE, location=OpenApiParameter.QUERY, required=False),
+            OpenApiParameter(name="date_to", type=OpenApiTypes.DATE, location=OpenApiParameter.QUERY, required=False),
+        ],
+        responses={200: TransactionHistorySerializer(many=True)},
+        tags=["Marketplace > Transactions"],
+    )
+    @action(detail=False, methods=["get"], url_path="history")
+    def history(self, request):
+        qs = list_transactions_for_user(user=request.user, status_filter="completada")
+
+        tx_type = request.query_params.get("transaction_type")
+        date_from = request.query_params.get("date_from")
+        date_to = request.query_params.get("date_to")
+
+        valid_types = [c for c, _ in Transaction.TRANSACTION_TYPE_CHOICES]
+        if tx_type and tx_type in valid_types:
+            qs = qs.filter(transaction_type=tx_type)
+        if date_from:
+            qs = qs.filter(created_at__date__gte=date_from)
+        if date_to:
+            qs = qs.filter(created_at__date__lte=date_to)
+
+        page = self.paginate_queryset(qs)
+        if page is not None:
+            serializer = TransactionHistorySerializer(page, many=True, context=self.get_serializer_context())
+            return self.get_paginated_response(serializer.data)
+
+        serializer = TransactionHistorySerializer(qs, many=True, context=self.get_serializer_context())
+        return Response(serializer.data)
+
+    @extend_schema(
+        summary="Rate a completed transaction",
+        description="Submit a 1-5 star rating and optional comment for a completed transaction. Each party can only submit one review per transaction.",
+        request=TransactionReviewCreateSerializer,
+        responses={201: None},
+        tags=["Marketplace > Transactions"],
+    )
+    @action(detail=True, methods=["post"], url_path="review")
+    def review(self, request, pk=None):
+        transaction = self.get_object()
+
+        if transaction.seller_id != request.user.id and transaction.buyer_id != request.user.id:
+            return Response({"detail": "No eres parte de esta transaccion."}, status=status.HTTP_403_FORBIDDEN)
+
+        if transaction.status != "completada":
+            return Response({"detail": "Solo puedes calificar transacciones completadas."}, status=status.HTTP_400_BAD_REQUEST)
+
+        if TransactionReview.objects.filter(transaction=transaction, reviewer=request.user).exists():
+            return Response({"detail": "Ya calificaste esta transaccion."}, status=status.HTTP_400_BAD_REQUEST)
+
+        serializer = TransactionReviewCreateSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        reviewee = transaction.buyer if transaction.seller_id == request.user.id else transaction.seller
+        TransactionReview.objects.create(
+            transaction=transaction,
+            reviewer=request.user,
+            reviewee=reviewee,
+            **serializer.validated_data,
+        )
+        return Response(status=status.HTTP_201_CREATED)

--- a/backend/marketplace/views/transaction.py
+++ b/backend/marketplace/views/transaction.py
@@ -141,9 +141,25 @@ class TransactionViewSet(
             "Supports filtering by transaction_type, date_from, and date_to."
         ),
         parameters=[
-            OpenApiParameter(name="transaction_type", type=OpenApiTypes.STR, location=OpenApiParameter.QUERY, required=False, enum=["donation", "sale", "swap"]),
-            OpenApiParameter(name="date_from", type=OpenApiTypes.DATE, location=OpenApiParameter.QUERY, required=False),
-            OpenApiParameter(name="date_to", type=OpenApiTypes.DATE, location=OpenApiParameter.QUERY, required=False),
+            OpenApiParameter(
+                name="transaction_type",
+                type=OpenApiTypes.STR,
+                location=OpenApiParameter.QUERY,
+                required=False,
+                enum=["donation", "sale", "swap"],
+            ),
+            OpenApiParameter(
+                name="date_from",
+                type=OpenApiTypes.DATE,
+                location=OpenApiParameter.QUERY,
+                required=False,
+            ),
+            OpenApiParameter(
+                name="date_to",
+                type=OpenApiTypes.DATE,
+                location=OpenApiParameter.QUERY,
+                required=False,
+            ),
         ],
         responses={200: TransactionHistorySerializer(many=True)},
         tags=["Marketplace > Transactions"],
@@ -166,10 +182,14 @@ class TransactionViewSet(
 
         page = self.paginate_queryset(qs)
         if page is not None:
-            serializer = TransactionHistorySerializer(page, many=True, context=self.get_serializer_context())
+            serializer = TransactionHistorySerializer(
+                page, many=True, context=self.get_serializer_context()
+            )
             return self.get_paginated_response(serializer.data)
 
-        serializer = TransactionHistorySerializer(qs, many=True, context=self.get_serializer_context())
+        serializer = TransactionHistorySerializer(
+            qs, many=True, context=self.get_serializer_context()
+        )
         return Response(serializer.data)
 
     @extend_schema(
@@ -183,19 +203,37 @@ class TransactionViewSet(
     def review(self, request, pk=None):
         transaction = self.get_object()
 
-        if transaction.seller_id != request.user.id and transaction.buyer_id != request.user.id:
-            return Response({"detail": "No eres parte de esta transaccion."}, status=status.HTTP_403_FORBIDDEN)
+        if (
+            transaction.seller_id != request.user.id
+            and transaction.buyer_id != request.user.id
+        ):
+            return Response(
+                {"detail": "No eres parte de esta transaccion."},
+                status=status.HTTP_403_FORBIDDEN,
+            )
 
         if transaction.status != "completada":
-            return Response({"detail": "Solo puedes calificar transacciones completadas."}, status=status.HTTP_400_BAD_REQUEST)
+            return Response(
+                {"detail": "Solo puedes calificar transacciones completadas."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
 
-        if TransactionReview.objects.filter(transaction=transaction, reviewer=request.user).exists():
-            return Response({"detail": "Ya calificaste esta transaccion."}, status=status.HTTP_400_BAD_REQUEST)
+        if TransactionReview.objects.filter(
+            transaction=transaction, reviewer=request.user
+        ).exists():
+            return Response(
+                {"detail": "Ya calificaste esta transaccion."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
 
         serializer = TransactionReviewCreateSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
 
-        reviewee = transaction.buyer if transaction.seller_id == request.user.id else transaction.seller
+        reviewee = (
+            transaction.buyer
+            if transaction.seller_id == request.user.id
+            else transaction.seller
+        )
         TransactionReview.objects.create(
             transaction=transaction,
             reviewer=request.user,

--- a/frontend/src/app/auth/verify/VerifyContent.tsx
+++ b/frontend/src/app/auth/verify/VerifyContent.tsx
@@ -5,7 +5,7 @@ import { useRouter, useSearchParams } from 'next/navigation';
 
 type ConfirmResponse = {
   message?: string;
-  user?: any;
+  user?: Record<string, unknown>;
   tokens?: { access: string; refresh: string };
   error?: { code?: string; message?: string };
 };

--- a/frontend/src/app/communities/page.tsx
+++ b/frontend/src/app/communities/page.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useState } from 'react';
 import Link from 'next/link';
-import { Plus, Users, Check, X, Mail } from 'lucide-react';
+import { Plus, Users, Check, Mail } from 'lucide-react';
 
 import { useAuth } from '@/hooks/useAuth';
 import { useCommunities } from '@/hooks/useCommunities';

--- a/frontend/src/app/transaction-history/page.tsx
+++ b/frontend/src/app/transaction-history/page.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import { History } from 'lucide-react';
+
+import TransactionFiltersPanel from '@/components/transactions/TransactionFiltersPanel';
+import TransactionList from '@/components/transactions/TransactionList';
+import { useTransactionHistory } from '@/hooks/useTransactionHistory';
+
+export default function TransactionHistoryPage() {
+  const {
+    transactions,
+    totalCount,
+    currentPage,
+    hasNextPage,
+    hasPrevPage,
+    isLoading,
+    error,
+    filters,
+    applyFilters,
+    goToPage,
+    retry,
+  } = useTransactionHistory();
+
+  return (
+    <main className="px-6 py-8">
+      <div className="space-y-6">
+        <header className="rounded-xl border border-border bg-card p-4 sm:p-5">
+          <div className="inline-flex items-center gap-2">
+            <History className="h-5 w-5 text-info" />
+            <h1 className="text-h1 font-bold text-fg">Historial de transacciones</h1>
+          </div>
+          <p className="mt-2 text-sm text-muted-fg">
+            Consulta tus transacciones completadas y califica tu experiencia.
+          </p>
+        </header>
+
+        <TransactionFiltersPanel filters={filters} onApply={applyFilters} />
+
+        <TransactionList
+          transactions={transactions}
+          isLoading={isLoading}
+          error={error}
+          totalCount={totalCount}
+          currentPage={currentPage}
+          hasNextPage={hasNextPage}
+          hasPrevPage={hasPrevPage}
+          onRetry={retry}
+          onPageChange={goToPage}
+        />
+      </div>
+    </main>
+  );
+}

--- a/frontend/src/components/layout/Navbar.tsx
+++ b/frontend/src/components/layout/Navbar.tsx
@@ -3,8 +3,8 @@
 import Link from 'next/link';
 import { usePathname, useRouter } from 'next/navigation';
 import { useState } from 'react';
-import { Bell, LogOut, Menu, Plus, ArrowLeftRight, User, X } from 'lucide-react';
 import { NAV_LINKS } from '@/components/layout/navLinks';
+import { Bell, User, LogOut, Menu, X, Plus, ArrowLeftRight, History } from 'lucide-react';
 import { useAuth } from '@/hooks/useAuth';
 
 export default function Navbar() {
@@ -108,6 +108,13 @@ export default function Navbar() {
                       >
                         <ArrowLeftRight className="h-4 w-4 text-info" /> Transacciones
                       </Link>
+                      <Link
+                        href="/transaction-history"
+                        onClick={() => setProfileOpen(false)}
+                        className="flex items-center gap-2 px-4 py-2.5 text-sm text-fg transition-colors hover:bg-info/10"
+                      >
+                        <History className="h-4 w-4 text-info" /> Historial de transacciones
+                      </Link>
                       <button
                         onClick={handleSignOut}
                         className="flex w-full items-center gap-2 px-4 py-2.5 text-left text-sm text-error transition-colors hover:bg-error/5"
@@ -207,6 +214,13 @@ export default function Navbar() {
                 className="flex items-center gap-3 rounded-lg px-3 py-2.5 text-sm font-medium text-info transition-colors hover:bg-info/10"
               >
                 <ArrowLeftRight className="h-5 w-5" /> Transacciones
+              </Link>
+              <Link
+                href="/transaction-history"
+                onClick={closeMenu}
+                className="flex items-center gap-3 rounded-lg px-3 py-2.5 text-sm font-medium text-info transition-colors hover:bg-info/10"
+              >
+                <History className="h-5 w-5" /> Historial de transacciones
               </Link>
               <button
                 onClick={handleSignOut}

--- a/frontend/src/components/transactions/StarRating.tsx
+++ b/frontend/src/components/transactions/StarRating.tsx
@@ -7,12 +7,17 @@ interface StarRatingProps {
   size?: 'sm' | 'md';
 }
 
-export default function StarRating({ value, onChange, readonly = false, size = 'md' }: StarRatingProps) {
+export default function StarRating({
+  value,
+  onChange,
+  readonly = false,
+  size = 'md',
+}: StarRatingProps) {
   const sizeClass = size === 'sm' ? 'h-4 w-4' : 'h-6 w-6';
 
   return (
     <div className="flex gap-0.5" role={readonly ? undefined : 'group'} aria-label="Calificacion">
-      {[1, 2, 3, 4, 5].map((star) => (
+      {[1, 2, 3, 4, 5].map(star => (
         <button
           key={star}
           type="button"

--- a/frontend/src/components/transactions/StarRating.tsx
+++ b/frontend/src/components/transactions/StarRating.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+interface StarRatingProps {
+  value: number;
+  onChange?: (rating: number) => void;
+  readonly?: boolean;
+  size?: 'sm' | 'md';
+}
+
+export default function StarRating({ value, onChange, readonly = false, size = 'md' }: StarRatingProps) {
+  const sizeClass = size === 'sm' ? 'h-4 w-4' : 'h-6 w-6';
+
+  return (
+    <div className="flex gap-0.5" role={readonly ? undefined : 'group'} aria-label="Calificacion">
+      {[1, 2, 3, 4, 5].map((star) => (
+        <button
+          key={star}
+          type="button"
+          disabled={readonly}
+          onClick={() => onChange?.(star)}
+          className={[
+            sizeClass,
+            'transition-colors',
+            readonly ? 'cursor-default' : 'cursor-pointer hover:scale-110',
+            star <= value ? 'text-yellow-400' : 'text-gray-300',
+          ].join(' ')}
+          aria-label={readonly ? undefined : `${star} estrella${star > 1 ? 's' : ''}`}
+        >
+          <svg viewBox="0 0 20 20" fill="currentColor" className="h-full w-full">
+            <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" />
+          </svg>
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/transactions/TransactionFiltersPanel.tsx
+++ b/frontend/src/components/transactions/TransactionFiltersPanel.tsx
@@ -1,0 +1,108 @@
+'use client';
+
+import { useState } from 'react';
+import type { TransactionFilters, TransactionType } from '@/types/transaction';
+
+interface TransactionFiltersProps {
+  filters: TransactionFilters;
+  onApply: (filters: TransactionFilters) => void;
+}
+
+const TRANSACTION_TYPES: { value: TransactionType; label: string }[] = [
+  { value: 'sale', label: 'Venta' },
+  { value: 'donation', label: 'Donacion' },
+  { value: 'swap', label: 'Intercambio' },
+];
+
+export default function TransactionFiltersPanel({ filters, onApply }: TransactionFiltersProps) {
+  const [type, setType] = useState<TransactionType | ''>(filters.transaction_type ?? '');
+  const [dateFrom, setDateFrom] = useState(filters.date_from ?? '');
+  const [dateTo, setDateTo] = useState(filters.date_to ?? '');
+
+  function handleApply() {
+    onApply({
+      ...(type && { transaction_type: type }),
+      ...(dateFrom && { date_from: dateFrom }),
+      ...(dateTo && { date_to: dateTo }),
+    });
+  }
+
+  function handleClear() {
+    setType('');
+    setDateFrom('');
+    setDateTo('');
+    onApply({});
+  }
+
+  const hasActiveFilters = Boolean(filters.transaction_type || filters.date_from || filters.date_to);
+
+  return (
+    <div className="rounded-2xl border border-border bg-card p-4">
+      <div className="flex flex-wrap gap-4">
+        <div className="flex flex-col gap-1">
+          <label htmlFor="tx-type" className="text-xs font-medium text-muted-fg">
+            Tipo
+          </label>
+          <select
+            id="tx-type"
+            value={type}
+            onChange={(e) => setType(e.target.value as TransactionType | '')}
+            className="rounded-lg border border-border bg-background px-3 py-1.5 text-sm text-fg focus:outline-none focus:ring-2 focus:ring-primary"
+          >
+            <option value="">Todos</option>
+            {TRANSACTION_TYPES.map((t) => (
+              <option key={t.value} value={t.value}>
+                {t.label}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div className="flex flex-col gap-1">
+          <label htmlFor="date-from" className="text-xs font-medium text-muted-fg">
+            Desde
+          </label>
+          <input
+            id="date-from"
+            type="date"
+            value={dateFrom}
+            max={dateTo || undefined}
+            onChange={(e) => setDateFrom(e.target.value)}
+            className="rounded-lg border border-border bg-background px-3 py-1.5 text-sm text-fg focus:outline-none focus:ring-2 focus:ring-primary"
+          />
+        </div>
+
+        <div className="flex flex-col gap-1">
+          <label htmlFor="date-to" className="text-xs font-medium text-muted-fg">
+            Hasta
+          </label>
+          <input
+            id="date-to"
+            type="date"
+            value={dateTo}
+            min={dateFrom || undefined}
+            onChange={(e) => setDateTo(e.target.value)}
+            className="rounded-lg border border-border bg-background px-3 py-1.5 text-sm text-fg focus:outline-none focus:ring-2 focus:ring-primary"
+          />
+        </div>
+
+        <div className="flex items-end gap-2">
+          <button
+            onClick={handleApply}
+            className="rounded-xl bg-btn-primary px-4 py-1.5 text-sm font-medium text-btn-primary-fg transition-colors hover:bg-primary-hover"
+          >
+            Filtrar
+          </button>
+          {hasActiveFilters && (
+            <button
+              onClick={handleClear}
+              className="rounded-xl border border-border px-4 py-1.5 text-sm font-medium text-muted-fg transition-colors hover:bg-muted"
+            >
+              Limpiar
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/transactions/TransactionFiltersPanel.tsx
+++ b/frontend/src/components/transactions/TransactionFiltersPanel.tsx
@@ -34,7 +34,9 @@ export default function TransactionFiltersPanel({ filters, onApply }: Transactio
     onApply({});
   }
 
-  const hasActiveFilters = Boolean(filters.transaction_type || filters.date_from || filters.date_to);
+  const hasActiveFilters = Boolean(
+    filters.transaction_type || filters.date_from || filters.date_to,
+  );
 
   return (
     <div className="rounded-2xl border border-border bg-card p-4">
@@ -46,11 +48,11 @@ export default function TransactionFiltersPanel({ filters, onApply }: Transactio
           <select
             id="tx-type"
             value={type}
-            onChange={(e) => setType(e.target.value as TransactionType | '')}
+            onChange={e => setType(e.target.value as TransactionType | '')}
             className="rounded-lg border border-border bg-background px-3 py-1.5 text-sm text-fg focus:outline-none focus:ring-2 focus:ring-primary"
           >
             <option value="">Todos</option>
-            {TRANSACTION_TYPES.map((t) => (
+            {TRANSACTION_TYPES.map(t => (
               <option key={t.value} value={t.value}>
                 {t.label}
               </option>
@@ -67,7 +69,7 @@ export default function TransactionFiltersPanel({ filters, onApply }: Transactio
             type="date"
             value={dateFrom}
             max={dateTo || undefined}
-            onChange={(e) => setDateFrom(e.target.value)}
+            onChange={e => setDateFrom(e.target.value)}
             className="rounded-lg border border-border bg-background px-3 py-1.5 text-sm text-fg focus:outline-none focus:ring-2 focus:ring-primary"
           />
         </div>
@@ -81,7 +83,7 @@ export default function TransactionFiltersPanel({ filters, onApply }: Transactio
             type="date"
             value={dateTo}
             min={dateFrom || undefined}
-            onChange={(e) => setDateTo(e.target.value)}
+            onChange={e => setDateTo(e.target.value)}
             className="rounded-lg border border-border bg-background px-3 py-1.5 text-sm text-fg focus:outline-none focus:ring-2 focus:ring-primary"
           />
         </div>

--- a/frontend/src/components/transactions/TransactionHistoryCard.tsx
+++ b/frontend/src/components/transactions/TransactionHistoryCard.tsx
@@ -95,9 +95,7 @@ export default function TransactionHistoryCard({ transaction }: { transaction: T
         <div className="border-t border-border pt-3">
           <p className="mb-1 text-xs font-medium text-fg">Tu calificacion</p>
           <StarRating value={myReview.rating} readonly size="sm" />
-          {myReview.comment && (
-            <p className="mt-1 text-xs text-muted-fg">{myReview.comment}</p>
-          )}
+          {myReview.comment && <p className="mt-1 text-xs text-muted-fg">{myReview.comment}</p>}
         </div>
       ) : canReview && !showForm ? (
         <div className="border-t border-border pt-3">
@@ -109,10 +107,7 @@ export default function TransactionHistoryCard({ transaction }: { transaction: T
           </button>
         </div>
       ) : showForm ? (
-        <TransactionReviewForm
-          transactionId={transaction.id}
-          onSubmitted={handleReviewSubmitted}
-        />
+        <TransactionReviewForm transactionId={transaction.id} onSubmitted={handleReviewSubmitted} />
       ) : null}
     </Card>
   );

--- a/frontend/src/components/transactions/TransactionHistoryCard.tsx
+++ b/frontend/src/components/transactions/TransactionHistoryCard.tsx
@@ -1,0 +1,119 @@
+'use client';
+
+import { useState } from 'react';
+import { CalendarDays, MapPin, Tag, User, UserRoundCheck } from 'lucide-react';
+
+import StarRating from '@/components/transactions/StarRating';
+import TransactionReviewForm from '@/components/transactions/TransactionReviewForm';
+import TransactionStatusBadge from '@/components/transactions/TransactionStatusBadge';
+import Card from '@/components/ui/Card';
+import { getTransactionTypeStyle } from '@/lib/productStyles';
+import { formatPrice } from '@/lib/utils';
+import type { Transaction, TransactionReview } from '@/types/transaction';
+
+const TYPE_LABELS: Record<string, string> = {
+  sale: 'Venta',
+  donation: 'Donacion',
+  swap: 'Intercambio',
+};
+
+export default function TransactionHistoryCard({ transaction }: { transaction: Transaction }) {
+  const [canReview, setCanReview] = useState(transaction.can_review ?? false);
+  const [myReview, setMyReview] = useState<TransactionReview | null>(transaction.my_review ?? null);
+  const [showForm, setShowForm] = useState(false);
+
+  const typeLabel = TYPE_LABELS[transaction.transaction_type] ?? transaction.transaction_type;
+  const typeClass = getTransactionTypeStyle(transaction.transaction_type);
+
+  function handleReviewSubmitted(review: TransactionReview) {
+    setMyReview(review);
+    setCanReview(false);
+    setShowForm(false);
+  }
+
+  return (
+    <Card className="space-y-4">
+      {/* Header */}
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="flex items-center gap-3">
+          {transaction.product.image_url && (
+            <img
+              src={transaction.product.image_url}
+              alt={transaction.product.title}
+              className="h-14 w-14 shrink-0 rounded-xl object-cover"
+            />
+          )}
+          <div>
+            <h3 className="text-base font-semibold text-fg">{transaction.product.title}</h3>
+            <p className="text-sm text-muted-fg">
+              {transaction.transaction_type === 'sale'
+                ? formatPrice(transaction.product.price)
+                : typeLabel}
+            </p>
+          </div>
+        </div>
+        <div className="flex items-center gap-2">
+          <span className={`rounded-md border px-2 py-1 text-xs font-medium ${typeClass}`}>
+            {typeLabel}
+          </span>
+          <TransactionStatusBadge status={transaction.status} />
+        </div>
+      </div>
+
+      {/* Details */}
+      <div className="grid gap-2 text-sm text-muted-fg sm:grid-cols-2">
+        <p className="flex items-center gap-2">
+          <User className="h-4 w-4 text-secondary" />
+          Comprador: {transaction.buyer.first_name} {transaction.buyer.last_name}
+        </p>
+        <p className="flex items-center gap-2">
+          <UserRoundCheck className="h-4 w-4 text-accent" />
+          Vendedor: {transaction.seller.first_name} {transaction.seller.last_name}
+        </p>
+        {transaction.delivery_location && (
+          <p className="flex items-center gap-2">
+            <MapPin className="h-4 w-4 text-info" />
+            {transaction.delivery_location}
+          </p>
+        )}
+        <p className="flex items-center gap-2">
+          <CalendarDays className="h-4 w-4 text-muted-fg" />
+          {new Date(transaction.created_at).toLocaleDateString('es-MX', {
+            year: 'numeric',
+            month: 'short',
+            day: 'numeric',
+          })}
+        </p>
+        <p className="flex items-center gap-2">
+          <Tag className="h-4 w-4 text-muted-fg" />
+          {transaction.product.category?.name ?? '—'}
+        </p>
+      </div>
+
+      {/* Rating section */}
+      {myReview ? (
+        <div className="border-t border-border pt-3">
+          <p className="mb-1 text-xs font-medium text-fg">Tu calificacion</p>
+          <StarRating value={myReview.rating} readonly size="sm" />
+          {myReview.comment && (
+            <p className="mt-1 text-xs text-muted-fg">{myReview.comment}</p>
+          )}
+        </div>
+      ) : canReview && !showForm ? (
+        <div className="border-t border-border pt-3">
+          <button
+            onClick={() => setShowForm(true)}
+            className="rounded-xl bg-btn-primary px-4 py-1.5 text-sm font-medium text-btn-primary-fg transition-colors hover:bg-primary-hover"
+          >
+            Calificar transaccion
+          </button>
+        </div>
+      ) : showForm ? (
+        <TransactionReviewForm
+          transactionId={transaction.id}
+          onSubmitted={handleReviewSubmitted}
+        />
+      ) : null}
+    </Card>
+  );
+}

--- a/frontend/src/components/transactions/TransactionList.tsx
+++ b/frontend/src/components/transactions/TransactionList.tsx
@@ -1,0 +1,104 @@
+import TransactionHistoryCard from '@/components/transactions/TransactionHistoryCard';
+import type { Transaction } from '@/types/transaction';
+
+interface TransactionListProps {
+  transactions: Transaction[];
+  isLoading: boolean;
+  error: string | null;
+  totalCount: number;
+  currentPage: number;
+  hasNextPage: boolean;
+  hasPrevPage: boolean;
+  onRetry: () => void;
+  onPageChange: (page: number) => void;
+}
+
+function SkeletonCard() {
+  return (
+    <div className="flex items-start gap-4 rounded-2xl border border-border bg-card p-4">
+      <div className="h-16 w-16 shrink-0 animate-pulse rounded-xl bg-muted" />
+      <div className="flex-1 space-y-2">
+        <div className="h-4 w-3/4 animate-pulse rounded bg-muted" />
+        <div className="h-3 w-1/2 animate-pulse rounded bg-muted" />
+        <div className="h-3 w-1/3 animate-pulse rounded bg-muted" />
+      </div>
+    </div>
+  );
+}
+
+export default function TransactionList({
+  transactions,
+  isLoading,
+  error,
+  totalCount,
+  currentPage,
+  hasNextPage,
+  hasPrevPage,
+  onRetry,
+  onPageChange,
+}: TransactionListProps) {
+  if (isLoading) {
+    return (
+      <div className="space-y-3">
+        {[1, 2, 3, 4].map((i) => (
+          <SkeletonCard key={i} />
+        ))}
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex flex-col items-center gap-4 rounded-2xl border border-dashed border-border bg-muted/50 p-8 text-center">
+        <p className="text-sm text-destructive">{error}</p>
+        <button
+          onClick={onRetry}
+          className="rounded-xl bg-btn-primary px-4 py-2 text-sm font-medium text-btn-primary-fg transition-colors hover:bg-primary-hover"
+        >
+          Intentar de nuevo
+        </button>
+      </div>
+    );
+  }
+
+  if (transactions.length === 0) {
+    return (
+      <div className="flex flex-col items-center gap-2 rounded-2xl border border-dashed border-border bg-muted/50 p-8 text-center">
+        <p className="text-sm font-medium text-fg">Sin transacciones</p>
+        <p className="text-xs text-muted-fg">No se encontraron transacciones con los filtros seleccionados.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <p className="text-xs text-muted-fg">{totalCount} transacciones encontradas</p>
+
+      <div className="space-y-3">
+        {transactions.map((tx) => (
+          <TransactionHistoryCard key={tx.id} transaction={tx} />
+        ))}
+      </div>
+
+      {(hasPrevPage || hasNextPage) && (
+        <div className="flex items-center justify-between pt-2">
+          <button
+            onClick={() => onPageChange(currentPage - 1)}
+            disabled={!hasPrevPage}
+            className="rounded-xl border border-border px-4 py-1.5 text-sm font-medium text-fg transition-colors hover:bg-muted disabled:cursor-not-allowed disabled:opacity-40"
+          >
+            Anterior
+          </button>
+          <span className="text-sm text-muted-fg">Pagina {currentPage}</span>
+          <button
+            onClick={() => onPageChange(currentPage + 1)}
+            disabled={!hasNextPage}
+            className="rounded-xl border border-border px-4 py-1.5 text-sm font-medium text-fg transition-colors hover:bg-muted disabled:cursor-not-allowed disabled:opacity-40"
+          >
+            Siguiente
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/transactions/TransactionList.tsx
+++ b/frontend/src/components/transactions/TransactionList.tsx
@@ -40,7 +40,7 @@ export default function TransactionList({
   if (isLoading) {
     return (
       <div className="space-y-3">
-        {[1, 2, 3, 4].map((i) => (
+        {[1, 2, 3, 4].map(i => (
           <SkeletonCard key={i} />
         ))}
       </div>
@@ -65,7 +65,9 @@ export default function TransactionList({
     return (
       <div className="flex flex-col items-center gap-2 rounded-2xl border border-dashed border-border bg-muted/50 p-8 text-center">
         <p className="text-sm font-medium text-fg">Sin transacciones</p>
-        <p className="text-xs text-muted-fg">No se encontraron transacciones con los filtros seleccionados.</p>
+        <p className="text-xs text-muted-fg">
+          No se encontraron transacciones con los filtros seleccionados.
+        </p>
       </div>
     );
   }
@@ -75,7 +77,7 @@ export default function TransactionList({
       <p className="text-xs text-muted-fg">{totalCount} transacciones encontradas</p>
 
       <div className="space-y-3">
-        {transactions.map((tx) => (
+        {transactions.map(tx => (
           <TransactionHistoryCard key={tx.id} transaction={tx} />
         ))}
       </div>

--- a/frontend/src/components/transactions/TransactionReviewForm.tsx
+++ b/frontend/src/components/transactions/TransactionReviewForm.tsx
@@ -11,7 +11,10 @@ interface TransactionReviewFormProps {
   onSubmitted: (review: TransactionReview) => void;
 }
 
-export default function TransactionReviewForm({ transactionId, onSubmitted }: TransactionReviewFormProps) {
+export default function TransactionReviewForm({
+  transactionId,
+  onSubmitted,
+}: TransactionReviewFormProps) {
   const [rating, setRating] = useState(0);
   const [comment, setComment] = useState('');
   const [isLoading, setIsLoading] = useState(false);
@@ -26,10 +29,10 @@ export default function TransactionReviewForm({ transactionId, onSubmitted }: Tr
     setIsLoading(true);
     setError(null);
     try {
-      const review = await submitTransactionReview(transactionId, {
+      const review = (await submitTransactionReview(transactionId, {
         rating,
         ...(comment.trim() && { comment: comment.trim() }),
-      }) as TransactionReview;
+      })) as TransactionReview;
       onSubmitted(review);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Error al enviar la calificacion.');
@@ -46,7 +49,7 @@ export default function TransactionReviewForm({ transactionId, onSubmitted }: Tr
 
       <textarea
         value={comment}
-        onChange={(e) => setComment(e.target.value)}
+        onChange={e => setComment(e.target.value)}
         placeholder="Comentario opcional..."
         rows={2}
         maxLength={500}

--- a/frontend/src/components/transactions/TransactionReviewForm.tsx
+++ b/frontend/src/components/transactions/TransactionReviewForm.tsx
@@ -29,10 +29,10 @@ export default function TransactionReviewForm({
     setIsLoading(true);
     setError(null);
     try {
-      const review = (await submitTransactionReview(transactionId, {
+      const review = await submitTransactionReview(transactionId, {
         rating,
         ...(comment.trim() && { comment: comment.trim() }),
-      })) as TransactionReview;
+      });
       onSubmitted(review);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Error al enviar la calificacion.');

--- a/frontend/src/components/transactions/TransactionReviewForm.tsx
+++ b/frontend/src/components/transactions/TransactionReviewForm.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import { useState } from 'react';
+
+import StarRating from '@/components/transactions/StarRating';
+import { submitTransactionReview } from '@/lib/api';
+import type { TransactionReview } from '@/types/transaction';
+
+interface TransactionReviewFormProps {
+  transactionId: number;
+  onSubmitted: (review: TransactionReview) => void;
+}
+
+export default function TransactionReviewForm({ transactionId, onSubmitted }: TransactionReviewFormProps) {
+  const [rating, setRating] = useState(0);
+  const [comment, setComment] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (rating === 0) {
+      setError('Selecciona una calificacion.');
+      return;
+    }
+    setIsLoading(true);
+    setError(null);
+    try {
+      const review = await submitTransactionReview(transactionId, {
+        rating,
+        ...(comment.trim() && { comment: comment.trim() }),
+      }) as TransactionReview;
+      onSubmitted(review);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Error al enviar la calificacion.');
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="mt-3 space-y-3 border-t border-border pt-3">
+      <p className="text-xs font-medium text-fg">Califica esta transaccion</p>
+
+      <StarRating value={rating} onChange={setRating} />
+
+      <textarea
+        value={comment}
+        onChange={(e) => setComment(e.target.value)}
+        placeholder="Comentario opcional..."
+        rows={2}
+        maxLength={500}
+        className="w-full resize-none rounded-lg border border-border bg-background px-3 py-2 text-sm text-fg placeholder:text-muted-fg focus:outline-none focus:ring-2 focus:ring-primary"
+      />
+
+      {error && <p className="text-xs text-destructive">{error}</p>}
+
+      <button
+        type="submit"
+        disabled={isLoading || rating === 0}
+        className="rounded-xl bg-btn-primary px-4 py-1.5 text-sm font-medium text-btn-primary-fg transition-colors hover:bg-primary-hover disabled:cursor-not-allowed disabled:opacity-50"
+      >
+        {isLoading ? 'Enviando...' : 'Enviar calificacion'}
+      </button>
+    </form>
+  );
+}

--- a/frontend/src/hooks/useTransactionHistory.ts
+++ b/frontend/src/hooks/useTransactionHistory.ts
@@ -18,7 +18,10 @@ export function useTransactionHistory() {
     setIsLoading(true);
     setError(null);
     try {
-      const data = await getTransactionHistory({ ...activeFilters, page }) as PaginatedResponse<Transaction>;
+      const data = (await getTransactionHistory({
+        ...activeFilters,
+        page,
+      })) as PaginatedResponse<Transaction>;
       setTransactions(data.results);
       setTotalCount(data.count);
       setCurrentPage(page);

--- a/frontend/src/hooks/useTransactionHistory.ts
+++ b/frontend/src/hooks/useTransactionHistory.ts
@@ -1,0 +1,63 @@
+import { useCallback, useEffect, useState } from 'react';
+
+import { getTransactionHistory } from '@/lib/api';
+import type { Transaction, TransactionFilters } from '@/types/transaction';
+import type { PaginatedResponse } from '@/types/api';
+
+export function useTransactionHistory() {
+  const [transactions, setTransactions] = useState<Transaction[]>([]);
+  const [totalCount, setTotalCount] = useState(0);
+  const [currentPage, setCurrentPage] = useState(1);
+  const [hasNextPage, setHasNextPage] = useState(false);
+  const [hasPrevPage, setHasPrevPage] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [filters, setFilters] = useState<TransactionFilters>({});
+
+  const fetchTransactions = useCallback(async (activeFilters: TransactionFilters, page = 1) => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const data = await getTransactionHistory({ ...activeFilters, page }) as PaginatedResponse<Transaction>;
+      setTransactions(data.results);
+      setTotalCount(data.count);
+      setCurrentPage(page);
+      setHasNextPage(Boolean(data.next));
+      setHasPrevPage(Boolean(data.previous));
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Error al cargar el historial';
+      setError(message);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchTransactions(filters, 1);
+  }, [fetchTransactions, filters]);
+
+  const applyFilters = useCallback((newFilters: TransactionFilters) => {
+    setFilters(newFilters);
+  }, []);
+
+  const goToPage = useCallback(
+    (page: number) => {
+      fetchTransactions(filters, page);
+    },
+    [fetchTransactions, filters],
+  );
+
+  return {
+    transactions,
+    totalCount,
+    currentPage,
+    hasNextPage,
+    hasPrevPage,
+    isLoading,
+    error,
+    filters,
+    applyFilters,
+    goToPage,
+    retry: () => fetchTransactions(filters, currentPage),
+  };
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -4,6 +4,7 @@ import type { PaginatedResponse } from '@/types/api';
 import type {
   CreateTransactionPayload,
   Transaction,
+  TransactionReview,
   UpdateTransactionStatusPayload,
 } from '@/types/transaction';
 
@@ -136,9 +137,9 @@ export async function getTransactionHistory(params?: {
 export async function submitTransactionReview(
   transactionId: number,
   payload: { rating: number; comment?: string },
-) {
+): Promise<TransactionReview> {
   return apiClient(`/marketplace/transactions/${transactionId}/review/`, {
     method: 'POST',
     body: JSON.stringify(payload),
-  });
+  }) as Promise<TransactionReview>;
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -115,3 +115,30 @@ export async function updateTransactionStatus(
     body: JSON.stringify(payload),
   });
 }
+
+// ===== Transactions =====
+
+export async function getTransactionHistory(params?: {
+  transaction_type?: string;
+  date_from?: string;
+  date_to?: string;
+  page?: number;
+}) {
+  const query = new URLSearchParams();
+  if (params?.transaction_type) query.set('transaction_type', params.transaction_type);
+  if (params?.date_from) query.set('date_from', params.date_from);
+  if (params?.date_to) query.set('date_to', params.date_to);
+  if (params?.page && params.page > 1) query.set('page', String(params.page));
+  const qs = query.toString();
+  return apiClient(`/marketplace/transactions/history/${qs ? `?${qs}` : ''}`);
+}
+
+export async function submitTransactionReview(
+  transactionId: number,
+  payload: { rating: number; comment?: string },
+) {
+  return apiClient(`/marketplace/transactions/${transactionId}/review/`, {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  });
+}

--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -55,7 +55,10 @@ async function authFetch<T>(endpoint: string, options?: RequestInit): Promise<T>
 
   if (response.status === 429) {
     const body = await response.json().catch(() => null);
-    throw new Error(body?.error?.message ?? 'Demasiadas solicitudes. Espera un momento antes de intentar de nuevo.');
+    throw new Error(
+      body?.error?.message ??
+        'Demasiadas solicitudes. Espera un momento antes de intentar de nuevo.',
+    );
   }
 
   if (!response.ok) {
@@ -98,7 +101,10 @@ export async function signIn(credentials: SignInRequest): Promise<AuthResponse> 
 
   if (response.status === 429) {
     const body = await response.json().catch(() => null);
-    throw new Error(body?.error?.message ?? 'Demasiadas solicitudes. Espera un momento antes de intentar de nuevo.');
+    throw new Error(
+      body?.error?.message ??
+        'Demasiadas solicitudes. Espera un momento antes de intentar de nuevo.',
+    );
   }
 
   if (!response.ok) {
@@ -122,7 +128,10 @@ export async function signUp(payload: SignUpRequest): Promise<unknown> {
   const body = await response.json().catch(() => ({}));
 
   if (response.status === 429) {
-    throw new Error(body?.error?.message ?? 'Demasiadas solicitudes. Espera un momento antes de intentar de nuevo.');
+    throw new Error(
+      body?.error?.message ??
+        'Demasiadas solicitudes. Espera un momento antes de intentar de nuevo.',
+    );
   }
 
   if (!response.ok) {

--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -102,7 +102,7 @@ export async function signIn(credentials: SignInRequest): Promise<AuthResponse> 
   return data;
 }
 
-export async function signUp(payload: SignUpRequest): Promise<any> {
+export async function signUp(payload: SignUpRequest): Promise<unknown> {
   const response = await fetch(`${API_BASE}/auth/signup/`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json', Accept: 'application/json' },

--- a/frontend/src/types/transaction.ts
+++ b/frontend/src/types/transaction.ts
@@ -1,7 +1,9 @@
 import type { Category, ProductCondition, ProductStatus, TransactionType } from '@/types/product';
 
+export type { TransactionType } from '@/types/product';
 export type TransactionStatus = 'pendiente' | 'confirmada' | 'completada' | 'cancelada';
 export type UpdatableTransactionStatus = 'confirmada' | 'completada' | 'cancelada';
+export type TransactionRole = 'seller' | 'buyer';
 
 export interface TransactionUserSummary {
   id: number;
@@ -22,6 +24,14 @@ export interface TransactionProductSummary {
   category: Category;
 }
 
+export interface TransactionReview {
+  id: number;
+  rating: number;
+  comment: string;
+  reviewer_name: string;
+  created_at: string;
+}
+
 export interface Transaction {
   id: number;
   product: TransactionProductSummary;
@@ -38,6 +48,9 @@ export interface Transaction {
   created_at: string;
   expires_at: string;
   is_expired: boolean;
+  // Present only from the /history/ endpoint
+  can_review?: boolean;
+  my_review?: TransactionReview | null;
 }
 
 export interface CreateTransactionPayload {
@@ -85,4 +98,15 @@ export interface TransactionsPaginationProps {
   hasPrevPage: boolean;
   onNext: () => void;
   onPrevious: () => void;
+}
+
+export interface TransactionFilters {
+  transaction_type?: TransactionType;
+  date_from?: string;
+  date_to?: string;
+}
+
+export interface SubmitReviewPayload {
+  rating: number;
+  comment?: string;
 }


### PR DESCRIPTION
Introduce transaction review support and a transaction history endpoint/UI. Backend: add TransactionReview model with rating/comment, unique constraint (one review per reviewer per transaction) and validators; register serializers and extend TransactionSerializer with TransactionHistorySerializer and review read/create serializers; add /transactions/history/ list action with filtering and /transactions/{id}/review/ POST action to submit reviews. Frontend: add transaction history page, filters panel, list/card components, star rating and review form, hook to fetch paginated history, API helpers for history and submitting reviews, and type updates. Also add .gitattributes and small navbar/urls cleanup. This enables users to view completed transactions, filter them, and submit a single 1-5 star review per transaction.

