### PR TITLE
fix(dev): resolver conflict markers commiteados

### DIFF
--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -10,13 +10,9 @@ from django.core.files.storage import default_storage
 from django.core.mail import send_mail
 from django.db.models import Q
 from django.utils import timezone
-<<<<<<< HEAD
 from rest_framework import generics, status, viewsets
-from rest_framework.decorators import action
-=======
-from rest_framework import generics, status
 from rest_framework import serializers as drf_serializers
->>>>>>> 4d3465df85cc2992e20bf566c58da49dfe2c6a45
+from rest_framework.decorators import action
 from rest_framework.parsers import MultiPartParser
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
@@ -643,7 +639,6 @@ class ProfilePictureUploadView(APIView):
         return Response({"profile_picture": file_url}, status=status.HTTP_200_OK)
 
 
-<<<<<<< HEAD
 class NotificationViewSet(viewsets.ReadOnlyModelViewSet):
     serializer_class = NotificationSerializer
     permission_classes = [IsAuthenticated]
@@ -660,8 +655,6 @@ class NotificationViewSet(viewsets.ReadOnlyModelViewSet):
         notification.read_at = timezone.now()
         notification.save(update_fields=["is_read", "read_at"])
         return Response({"status": "notification marked as read"})
-=======
-# ── Share Item with Friends (HU-CORE-12) ─────────────────
 
 
 class ShareItemView(APIView):
@@ -746,4 +739,3 @@ class ShareItemView(APIView):
             {"message": f"Producto compartido con {len(friend_ids)} amigo(s)."},
             status=status.HTTP_201_CREATED,
         )
->>>>>>> 4d3465df85cc2992e20bf566c58da49dfe2c6a45

--- a/backend/gamification/signals.py
+++ b/backend/gamification/signals.py
@@ -1,42 +1,10 @@
 from django.db.models.signals import post_save
 from django.dispatch import receiver
-<<<<<<< HEAD
-
-from core.models.user import User
-from gamification.services.badge_service import evaluate_milestones
-from marketplace.models.product import Products
-from marketplace.models.transaction import Transaction
-
-
-@receiver(post_save, sender=Products)
-def product_post_save(sender, instance, created, **kwargs):
-    if created:
-        evaluate_milestones(instance.seller)
-    else:
-        update_fields = kwargs.get("update_fields")
-        if not update_fields or "status" in update_fields or "transaction_type" in update_fields:
-            evaluate_milestones(instance.seller)
-
-
-@receiver(post_save, sender=Transaction)
-def transaction_post_save(sender, instance, created, **kwargs):
-    if instance.status == "completada":
-        evaluate_milestones(instance.seller)
-        evaluate_milestones(instance.buyer)
-
-
-@receiver(post_save, sender=User)
-def user_post_save(sender, instance, created, **kwargs):
-    if created:
-        evaluate_milestones(instance)
-    else:
-        update_fields = kwargs.get("update_fields")
-        if not update_fields or "phone" in update_fields or "profile_picture" in update_fields:
-            evaluate_milestones(instance)
-=======
 from rest_framework.exceptions import ValidationError
 
+from core.models.user import User
 from gamification.models import ChallengeType, PointAction, PointTransaction
+from gamification.services.badge_service import evaluate_milestones
 from gamification.services.challenge_service import refresh_user_active_challenges
 from gamification.services.point_service import award_points
 from marketplace.models import Products, Transaction, TransactionReview
@@ -63,6 +31,16 @@ def refresh_challenges_on_point_transaction(sender, instance, created, **kwargs)
 
 
 @receiver(post_save, sender=Products)
+def product_post_save(sender, instance, created, **kwargs):
+    if created:
+        evaluate_milestones(instance.seller)
+    else:
+        update_fields = kwargs.get("update_fields")
+        if not update_fields or "status" in update_fields or "transaction_type" in update_fields:
+            evaluate_milestones(instance.seller)
+
+
+@receiver(post_save, sender=Products)
 def award_points_on_product_publish(sender, instance, created, **kwargs):
     if not created:
         return
@@ -74,14 +52,18 @@ def award_points_on_product_publish(sender, instance, created, **kwargs):
             reference_id=instance.id,
         )
     except ValidationError:
-        # If point rules are missing, keep product published and skip gamification points.
         return
 
 
 @receiver(post_save, sender=Transaction)
+def transaction_post_save(sender, instance, created, **kwargs):
+    if instance.status == "completada":
+        evaluate_milestones(instance.seller)
+        evaluate_milestones(instance.buyer)
+
+
+@receiver(post_save, sender=Transaction)
 def refresh_challenges_on_completed_transaction(sender, instance, **kwargs):
-    # Fallback update for challenge progress when transaction status changes,
-    # even if point rules are missing or points were not awarded.
     if instance.status != "completada":
         return
 
@@ -113,6 +95,14 @@ def award_points_on_positive_review(sender, instance, created, **kwargs):
             reference_id=instance.id,
         )
     except ValidationError:
-        # If point rules are missing, keep review saved and skip gamification points.
         return
->>>>>>> 4d3465df85cc2992e20bf566c58da49dfe2c6a45
+
+
+@receiver(post_save, sender=User)
+def user_post_save(sender, instance, created, **kwargs):
+    if created:
+        evaluate_milestones(instance)
+    else:
+        update_fields = kwargs.get("update_fields")
+        if not update_fields or "phone" in update_fields or "profile_picture" in update_fields:
+            evaluate_milestones(instance)


### PR DESCRIPTION
limpieza de los conflict markers que quedaron commiteados en dev al mergear un pr sin resolver

afectados:
- backend/gamification/signals.py
- backend/core/views.py

ambos archivos tenian <<<<<<<, ======= y >>>>>>> commiteados, rompiendo el build del backend. resolucion preserva ambas features de las dos ramas (badges+challenges en signals, NotificationViewSet+ShareItemView en views).

los otros archivos afectados ya se arreglaron en merges previos (#150, #151).