### PR TITLE
fix(test): use exact match for Bloqueados selector in HU-GAM-04 suite

### DIFF
--- a/frontend/tests/gamification/badges-unlock.spec.ts
+++ b/frontend/tests/gamification/badges-unlock.spec.ts
@@ -111,7 +111,7 @@ test.describe('HU-GAM-04 – Desbloqueo de Medallas', () => {
       await page.goto('/profile');
       const section = badgesSection(page);
       await expect(section.getByText('Desbloqueados')).toBeVisible({ timeout: 10000 });
-      await expect(section.getByText('Bloqueados')).toBeVisible();
+      await expect(section.getByText('Bloqueados', { exact: true })).toBeVisible();
     });
 
     test('badge desbloqueado aparece con su nombre', async ({ page }) => {


### PR DESCRIPTION
getByText Bloqueados was matching both Desbloqueados and Bloqueados causing strict mode violation. Changed to exact true so AC2-AC4 tests run correctly.

## 📌 Summary
Briefly describe what this Pull Request does and why it is needed.

---

## 🔍 Type of Change
Mark the relevant option(s):

- [ ] Feature (new functionality)
- [ ] Bug fix
- [ ] Agent (development tooling)
- [ ] Documentation
- [ ] Refactor / cleanup
- [ ] CI / DevOps

---

## 🧩 Scope
Which part of the project is affected?

- [ ] Backend
- [ ] Frontend
- [ ] Agents
- [ ] Docs
- [ ] CI / Infrastructure

---

## 🤖 Agent Details (if applicable)
If this PR adds or updates an agent:

- **Agent name:**
- **Purpose of the agent:**
- **Input(s):**
- **Output(s):**
- **Example included:**  
  - [ ] Yes  
  - [ ] No (explain why)

---

## 🧪 Testing
Describe how this change was tested:

- [ ] Local execution
- [ ] Manual testing
- [ ] Unit tests
- [ ] Not applicable (explain why)

---

## 📎 Related Context
Link to related issues, discussions, or decisions (if any).

---

## ✅ Checklist
Before requesting a review, confirm that:

- [ ] Code builds and runs locally
- [ ] Changes are small and focused
- [ ] Code follows agreed standards
- [ ] Documentation was updated if needed
- [ ] No unrelated changes are included
- [ ] AI-generated content was reviewed and understood

---

## 📝 Notes for Reviewers
Anything reviewers should pay special attention to?
